### PR TITLE
Feature/plr 561 - merge to develop-providers branch

### DIFF
--- a/autotest-plr/data/error-list.json
+++ b/autotest-plr/data/error-list.json
@@ -73,5 +73,8 @@
     "duplicateFacilityFound": "PRS.SYS.ADR.UNK.1.0.7055: An existing facility address was found, can not create duplicate facility.",
     "civicAddressRecommendation": "PRS.SYS.ADR.UNK.1.0.7052: Civic Address is not valid - Recommendation is provided.",
     "confidentialRecordFound": "The search criteria matched confidential records that are not shown. Please search by identifier to view confidential record details."
+  },
+  "infos": {
+    "permissionRules": "Some results were removed under data permission rules."
   }
 }

--- a/autotest-plr/data/error-list.json
+++ b/autotest-plr/data/error-list.json
@@ -71,6 +71,7 @@
     "maximumResults": "Maximum search results returned. Please refine your search criteria.",
     "addressValidationFailed": "PRS.SYS.ADR.UNK.1.0.7054: Unable to validate Civic Address - Re-Enter.",
     "duplicateFacilityFound": "PRS.SYS.ADR.UNK.1.0.7055: An existing facility address was found, can not create duplicate facility.",
-    "civicAddressRecommendation": "PRS.SYS.ADR.UNK.1.0.7052: Civic Address is not valid - Recommendation is provided."
+    "civicAddressRecommendation": "PRS.SYS.ADR.UNK.1.0.7052: Civic Address is not valid - Recommendation is provided.",
+    "confidentialRecordFound": "The search criteria matched confidential records that are not shown. Please search by identifier to view confidential record details."
   }
 }

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/data/InjectableData.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/data/InjectableData.java
@@ -49,6 +49,23 @@ public class InjectableData
     }
 
     /**
+     * Provides just the BC Practitioner and Organization provider types for tests that need to cover only these types.
+     * (Includes null for second parameter to match builder method signature for a specific test)
+     *
+     * @return A two-dimensional array of BC Practitioner and Organization provider types.
+     */
+    @DataProvider(name = "indOrgBuilderTypes")
+    public static Object[][] getIndOrgBuilderTypes()
+    {
+        List<Object[]> data = new ArrayList<>();
+        for (ProviderType providerType : List.of(ProviderType.BC_PRACTITIONER, ProviderType.ORGANIZATION))
+        {
+            data.add(new Object[]{providerType,null});
+        }
+        return toArray(data);
+    }
+
+    /**
      * Provides a matrix of user types in PLR.
      *
      * @return a two-dimensional array of test parameters

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/data/InjectableData.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/data/InjectableData.java
@@ -3,14 +3,13 @@ package ca.bc.gov.health.qa.autotest.plr.data;
 import java.util.ArrayList;
 import java.util.List;
 
-import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.ProviderSection;
 import org.testng.annotations.DataProvider;
 
 import ca.bc.gov.health.qa.autotest.plr.util.ProviderType;
 import ca.bc.gov.health.qa.autotest.plr.util.UserType;
 
 /**
- * TODO (AZ) - doc
+ * Data Provider class to inject independent case types for testing (provider + user types typically)
  */
 public class InjectableData
 {
@@ -18,9 +17,9 @@ public class InjectableData
     {}
 
     /**
-     * TODO (AZ) - doc
+     * Provides a matrix of all provider types
      *
-     * @return ???
+     * @return A two-dimensional array of all provider types.
      */
     @DataProvider(name = "allProviderTypes")
     public static Object[][] getAllProviderTypes()
@@ -34,9 +33,25 @@ public class InjectableData
     }
 
     /**
-     * TODO (AZ) - doc
+     * Provides just the BC Practitioner and Organization provider types for tests that need to cover only these types.
      *
-     * @return ???
+     * @return A two-dimensional array of BC Practitioner and Organization provider types.
+     */
+    @DataProvider(name = "indOrgTypes")
+    public static Object[][] getIndOrgTypes()
+    {
+        List<Object[]> data = new ArrayList<>();
+        for (ProviderType providerType : List.of(ProviderType.BC_PRACTITIONER, ProviderType.ORGANIZATION))
+        {
+            data.add(new Object[]{providerType});
+        }
+        return toArray(data);
+    }
+
+    /**
+     * Provides a matrix of user types in PLR.
+     *
+     * @return a two-dimensional array of test parameters
      */
     @DataProvider(name = "allPlrUserTypes")
     public static Object[][] getAllPlrUserTypes()
@@ -68,9 +83,9 @@ public class InjectableData
     }
 
     /**
-     * TODO (AZ) - doc
+     * Provides a matrix of user type in PLR combined with each provider type.
      *
-     * @return ???
+     * @return a two-dimensional array of each possible pair of PLR user type and provider type
      */
     @DataProvider(name = "allPlrUserTypesProviderTypes")
     public static Object[][] getAllPlrUserTypesProviderTypes()

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/data/PlrData.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/data/PlrData.java
@@ -224,7 +224,7 @@ public class PlrData
     /**
      * Finds organizations with expected properties for tests, or creates them if they don't exist.
      *
-     * @param fhir          the FHIRController reference for fhir endpoint use
+     * @param fhir          the FHIRController reference for FHIR endpoint use
      * @param defaultMap    a map of default data set provider builders based on provider type
      * @param minimumMap    a map of minimum data set provider builders based on provider type
      */

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/data/PlrData.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/data/PlrData.java
@@ -16,7 +16,6 @@ import ca.bc.gov.health.qa.autotest.plr.fhir.data.organization.OrganizationDataG
 import ca.bc.gov.health.qa.autotest.plr.fhir.data.organization.OrganizationMaintainConfig;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.MaintainRequestBuilder;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.common.model.IdentifierType;
-import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.common.model.PractitionerRelationshipCode;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.facility.MaintainFacilityBuilder;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.MaintainIndividualBuilder;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.model.IndividualRoleType;
@@ -24,7 +23,6 @@ import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.query.Individua
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.MaintainOrgBuilder;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.model.OrgRoleType;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.query.OrgQueryCriteriaParams;
-import ca.bc.gov.health.qa.autotest.plr.web.actions.model.facility.Identifier;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 
@@ -36,7 +34,7 @@ import ca.bc.gov.health.qa.autotest.plr.util.UserType;
 import ca.bc.gov.health.qa.autotest.runner.util.log.ExecutionLogManager;
 
 /**
- * TODO (AZ) - doc
+ * PLR Data utility class for getting and setting up PLR test data.
  */
 public class PlrData
 {
@@ -90,9 +88,9 @@ public class PlrData
     }
 
     /**
-     * TODO (AZ) - doc
+     * Gets the PLR FHIR keystore path.
      *
-     * @return ???
+     * @return the keystore path
      */
     public static Path getKeyStorePath()
     {
@@ -120,18 +118,12 @@ public class PlrData
     }
 
     /**
-     * TODO (AZ) - doc
+     * Gets provider data for the given provider type and key.
      *
-     * @param providerType
-     *        ???
-     *
-     * @param key
-     *        ???
-     *
-     * @return ???
-     *
-     * @throws IllegalStateException
-     *         if the provider type is not supported
+     * @param providerType              the provider type
+     * @param key                       the provider key
+     * @return                          provider data as JSON object
+     * @throws IllegalStateException    if the provider type is not supported
      */
     @Deprecated
     public static JSONObject getProvider(ProviderType providerType, String key)
@@ -311,7 +303,7 @@ public class PlrData
     }
 
     /**
-     * TODO (KD) - doc
+     * Gets facility data for the given key.
      *
      * @param key the configuration key name
      * @return the string value for the given key, or null if absent

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/fhir/FHIRController.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/fhir/FHIRController.java
@@ -338,6 +338,7 @@ public class FHIRController implements AutoCloseable {
     public MaintainIndividualBuilder submitIndividual(MaintainIndividualBuilder builder) {
         String id = executor.submitMaintain(builder);
         LOG.info("Submitted individual (id={})", id);
+        builder.addIdentifier(IdentifierType.IPC, id);
         return builder;
     }
 

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/fhir/FHIRController.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/fhir/FHIRController.java
@@ -246,9 +246,10 @@ public class FHIRController implements AutoCloseable {
     }
 
     /**
-     * TODO
-     * @param builder
-     * @return
+     * Submits a pre-configured facility builder directly without generating new data.
+     * Useful when developers want full control over the builder data.
+     * @param builder pre-configured facility builder to submit
+     * @return the submitted builder with updated identifier
      */
     public MaintainFacilityBuilder submitFacility(MaintainFacilityBuilder builder) {
         String id = executor.submitMaintain(builder);

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/fhir/data/individual/IndividualBuilderFactory.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/fhir/data/individual/IndividualBuilderFactory.java
@@ -16,7 +16,10 @@ public class IndividualBuilderFactory {
 
     private final IndividualDataGenerator dataGen;
 
-    /** Create a new factory with the provided data generator. */
+    /**
+     * Create a new factory with the provided data generator.
+     * @param dataGen data generator to use for populating attributes
+     */
     public IndividualBuilderFactory(IndividualDataGenerator dataGen) {
         this.dataGen = dataGen;
     }

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/fhir/data/individual/IndividualMaintainConfig.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/fhir/data/individual/IndividualMaintainConfig.java
@@ -198,16 +198,20 @@ public class IndividualMaintainConfig {
      * @return count of DISCIPLINARY_ACTION entries */
     public int getDisciplinaryActionCount() { return disciplinaryActionCount; }
 
-    /** Gets the number of organization relationships configured.\n     * @return organization relationship count */
+    /** Gets the number of organization relationships configured.
+     * @return organization relationship count */
     public int getOrganizationRelationshipCount() { return organizationRelationshipCount; }
 
-    /** Checks if organization relationships are configured.\n     * @return true if organizationRelationshipCount > 0 */
+    /** Checks if organization relationships are configured.
+     * @return true if organizationRelationshipCount > 0 */
     public boolean hasOrganizationRelationships() { return organizationRelationshipCount > 0; }
 
-    /** Gets the number of individual relationships configured.\n     * @return individual relationship count */
+    /** Gets the number of individual relationships configured.
+     * @return individual relationship count */
     public int getIndividualRelationshipCount() { return individualRelationshipCount; }
 
-    /** Checks if individual relationships are configured.\n     * @return true if individualRelationshipCount > 0 */
+    /** Checks if individual relationships are configured.
+     * @return true if individualRelationshipCount > 0 */
     public boolean hasIndividualRelationships() { return individualRelationshipCount > 0; }
 
     // Fluent enabling

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/fhir/maintain/individual/query/IndividualQueryResponseMapper.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/fhir/maintain/individual/query/IndividualQueryResponseMapper.java
@@ -420,6 +420,9 @@ public final class IndividualQueryResponseMapper {
 			}
 		}
 
+		// Ensure CANADA is set to CA for future potential use in re-submission
+		if ("CANADA".equals(birthCountry)) birthCountry = "CA";
+
 		// Set demographics if we have at least some data
 		if (gender != null || birthDate != null) {
 			b.setDemographics(birthDate, birthCountry, birthProvince, gender, deathDate);

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/fhir/maintain/organization/query/OrgQueryResponseMapper.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/fhir/maintain/organization/query/OrgQueryResponseMapper.java
@@ -202,6 +202,13 @@ public final class OrgQueryResponseMapper {
 			}
 		}
 
+		// hack to detect confidential record found error
+		if (builders.isEmpty()) {
+			JSONObject topResource = topEntries.getJSONObject(0).optJSONObject("resource");
+			JSONObject errorDetails = topResource.optJSONArray("issue").optJSONObject(0).optJSONObject("details");
+			if (errorDetails.optString("text").contains("confidential")) { builders.add(new MaintainOrgBuilder().name("ConfidentialRecordFound")); }
+		}
+
 		return builders;
 	}
 

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/util/RelatedProviderIdentifierType.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/util/RelatedProviderIdentifierType.java
@@ -1,11 +1,20 @@
 package ca.bc.gov.health.qa.autotest.plr.util;
 
+/**
+ * Enum for Related Provider Identifier Types
+ */
 public enum RelatedProviderIdentifierType {
-	PHYID("PHYID - Pharmacy ID Number"), 
-	IPC("IPC - Internal Provider Code"), 
+	/** Pharmacy ID Number */
+	PHYID("PHYID - Pharmacy ID Number"),
+	/** Internal Provider Code */
+	IPC("IPC - Internal Provider Code"),
+	/** MSP Facility Number */
 	HFI("HFI - MSP Facility Number"),
-	CPN("CPN - Common Party Number"), 
-	HLBCID("HLBCID - Healthlinks ID"), 
+	/** Common Party Number */
+	CPN("CPN - Common Party Number"),
+	/** Healthlinks ID */
+	HLBCID("HLBCID - Healthlinks ID"),
+	/** Organization */
 	ORGID("ORGID - Organization");
 
 	private final String text;

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/actions/model/facility/ElectronicAddress.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/actions/model/facility/ElectronicAddress.java
@@ -106,6 +106,7 @@ public class ElectronicAddress {
 	 * TODO add specifications for these fields within the builder as much as possible in future versions
 	 *
 	 * @param fhirFacility	the facility to create the electronic address for
+	 * @param eaddress   	the electronic address map from the FHIR facility
 	 */
 	public ElectronicAddress(MaintainFacilityBuilder fhirFacility, Map<String,String> eaddress) {
 		super();

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/actions/provider/SearchProviderActions.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/actions/provider/SearchProviderActions.java
@@ -1,8 +1,17 @@
 package ca.bc.gov.health.qa.autotest.plr.web.actions.provider;
 
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.common.model.IdentifierType;
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.MaintainIndividualBuilder;
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.MaintainOrgBuilder;
+import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.SearchProviderPage;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.SearchProviderResultsFragment;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.ViewProviderPage;
+import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflow;
 import ca.bc.gov.health.qa.autotest.runner.util.selenium.SeleniumSession;
+
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
 
 /**
  * Actions class for the Search Provider page/functions
@@ -35,5 +44,26 @@ public class SearchProviderActions
         ViewProviderPage viewProvider = new ViewProviderPage(selenium_);
         viewProvider.waitForReady();
         return viewProvider;
+    }
+
+    public ViewProviderPage openConfidentialRecord(PlrWebWorkflow workflow, boolean isOrganization,
+                                                   MaintainOrgBuilder confOrg, MaintainIndividualBuilder confInd)
+    {
+        SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
+
+        String identifier;
+        if (isOrganization) identifier = confOrg.getIdentifier(IdentifierType.IPC);
+        else identifier = confInd.getIdentifier(IdentifierType.IPC);
+
+        SearchProviderResultsFragment results = provider.searchByIdentifier("IPC", identifier);
+        List<String> resultInfo = results.grabResultsRow(0);
+        assertEquals(resultInfo.getFirst(), "Link to View Provider", "Record name not confidentially masked");
+
+        ViewProviderPage page = openSearchResults(0);
+
+        assertEquals(page.getViewHeader().grabViewTitle().split(" ")[0], "Confidential",
+                "Record name in title not confidentially masked");
+
+        return page;
     }
 }

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/actions/provider/SearchProviderActions.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/actions/provider/SearchProviderActions.java
@@ -3,6 +3,7 @@ package ca.bc.gov.health.qa.autotest.plr.web.actions.provider;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.common.model.IdentifierType;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.MaintainIndividualBuilder;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.MaintainOrgBuilder;
+import ca.bc.gov.health.qa.autotest.plr.util.UserType;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.SearchProviderPage;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.SearchProviderResultsFragment;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.ViewProviderPage;
@@ -12,6 +13,7 @@ import ca.bc.gov.health.qa.autotest.runner.util.selenium.SeleniumSession;
 import java.util.List;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 /**
  * Actions class for the Search Provider page/functions
@@ -46,7 +48,7 @@ public class SearchProviderActions
         return viewProvider;
     }
 
-    public ViewProviderPage openConfidentialRecord(PlrWebWorkflow workflow, boolean isOrganization,
+    public ViewProviderPage openConfidentialRecord(PlrWebWorkflow workflow, UserType userType, boolean isOrganization,
                                                    MaintainOrgBuilder confOrg, MaintainIndividualBuilder confInd)
     {
         SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
@@ -57,12 +59,21 @@ public class SearchProviderActions
 
         SearchProviderResultsFragment results = provider.searchByIdentifier("IPC", identifier);
         List<String> resultInfo = results.grabResultsRow(0);
-        assertEquals(resultInfo.getFirst(), "Link to View Provider", "Record name not confidentially masked");
+        if (userType.equals(UserType.SECONDARY))
+            assertEquals(resultInfo.getFirst(), "Link to View Provider",
+                    "Record name not confidentially masked");
+        else // reg-admin or primary
+            assertNotEquals(resultInfo.getFirst(), "Link to View Provider",
+                    "Record name confidentially masked unexpectedly");
 
         ViewProviderPage page = openSearchResults(0);
 
-        assertEquals(page.getViewHeader().grabViewTitle().split(" ")[0], "Confidential",
+        if (userType.equals(UserType.SECONDARY))
+            assertEquals(page.getViewHeader().grabViewTitle().split(" ")[0], "Confidential",
                 "Record name in title not confidentially masked");
+        else // reg-admin or primary
+            assertNotEquals(page.getViewHeader().grabViewTitle().split(" ")[0], "Confidential",
+                    "Record name in title confidentially masked unexpectedly");
 
         return page;
     }

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/actions/provider/ViewProviderActions.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/actions/provider/ViewProviderActions.java
@@ -325,10 +325,6 @@ public class ViewProviderActions
                     provider.getString("owner") +
                     ") - " +
                     provider.getString("status");
-            default -> {
-                String msg = String.format("Unsupported provider type (%s).", providerType);
-                throw new IllegalStateException(msg);
-            }
         };
     }
 

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/facility/UpdateFacilityPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/facility/UpdateFacilityPage.java
@@ -54,7 +54,7 @@ public class UpdateFacilityPage extends ViewFacilityPage {
 	/**
 	 * Open facility detail view page
 	 *
-	 * @param fauthId
+	 * @param fauthId 	the facility auth ID to open
 	 * 
 	 */
 	public void openFacility(String fauthId) {
@@ -99,9 +99,9 @@ public class UpdateFacilityPage extends ViewFacilityPage {
 	/**
 	 * get Data Block Header Update Button Selector
 	 *
-	 * @param section
-	 * @param index
-	 * @return CSS selector of Data Block Header Update Button
+	 * @param section the facility section to select
+	 * @param index   the index of data block within the section to select
+	 * @return 		  CSS selector of Data Block Header Update Button
 	 */
 	protected String getDataBlockHeaderUpdateButtonSelector(FacilitySection section, int index) {
 		return getDataBlockHeaderSelector(section, index) + " > div.ui-panel-actions "
@@ -133,8 +133,10 @@ public class UpdateFacilityPage extends ViewFacilityPage {
 	}
 
 	/**
-	 * Using a Javascript Executor to press button
-	 * @param button
+	 * Clicks a button, waiting if necessary.
+	 * Uses a JavaScript Executor to press button if a normal click fails due to interception or stale element.
+	 *
+	 * @param button WebElement of button to be clicked
 	 */
 	private void clickbuttonWait(WebElement button) {
 		try {
@@ -174,10 +176,10 @@ public class UpdateFacilityPage extends ViewFacilityPage {
 	
 	
 	/**
-	 * Get Dialog Css selector
+	 * Get Dialog CSS selector
 	 *
-	 * @param section
-	 * @return string of dialog CSS selector
+	 * @param section   the facility section to select
+	 * @return 			string of dialog CSS selector
 	 */
 	private String getDialogCss(FacilitySection section) {
 		String dialogName =DIALOG_MAP.get(section).getDialogName();

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/facility/ViewFacilityPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/facility/ViewFacilityPage.java
@@ -213,11 +213,12 @@ public class ViewFacilityPage extends BasicWebPage {
 		}
 	}
 
-    /** TODO (KD) - doc
+    /**
+	 * Checks whether the expand/collapse button is displayed for a data block.
      *
-     * @param section
-     * @param index
-     * @return
+     * @param section   the facility section containing the data block
+     * @param index 	the zero-based index of the data block within the section
+     * @return 			true if the expand/collapse button is displayed; false otherwise
      */
 	public boolean isDataBlockExpandButtonDisplayed(FacilitySection section, int index) {
 		WebElement expandCollapseButton = selenium_
@@ -328,7 +329,7 @@ public class ViewFacilityPage extends BasicWebPage {
 
 
     /**
-     * TODO (KD) - doc
+     * Gets the content from a specific data block within a facility section
      *
      * @param section               the facility section to get content from
      * @param index                 the index of block within the facility section to get content from
@@ -380,7 +381,7 @@ public class ViewFacilityPage extends BasicWebPage {
 	/**
 	 * Open facility detail view page
 	 *
-	 * @param fauthId
+	 * @param fauthId 	the facility auth ID to open
 	 * 
 	 */
 	public void openFacility(String fauthId) {
@@ -442,11 +443,11 @@ public class ViewFacilityPage extends BasicWebPage {
 
 
 	/**
-	 * check data block active or not *
+	 * Checks whether a specific data block in a facility section is marked as active.
 	 * 
-	 * @param section
-	 * @param index
-	 * 
+	 * @param section   the facility section to select
+	 * @param index  	the index of data block to specifically check within the facility section
+	 * @return 			true if the data block is marked as active; false otherwise
 	 */
 	public boolean grabDataBlockActive(FacilitySection section, int index) {
 		By locator = By.cssSelector(getDataBlockHeaderActiveSelector(section, index));
@@ -454,13 +455,12 @@ public class ViewFacilityPage extends BasicWebPage {
 	}
 
 	/**
-	 * get data block header active selector *
+	 * Gets the CSS selector for the active icon in a data block header.
 	 * 
-	 * @param section
-	 * @param index
+	 * @param section   the facility section to select
+	 * @param index 	the index of data block to specifically select within the facility section
 	 * 
 	 */
-
 	protected String getDataBlockHeaderActiveSelector(FacilitySection section, int index) {
 		return getDataBlockHeaderSelector(section, index) + " > div.ui-panel-actions > span > img[title='Active']";
 	}

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/SearchProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/SearchProviderPage.java
@@ -654,36 +654,41 @@ extends BasicWebPage
     }
 
     /**
+     * Grabs all alert messages displayed on the page.
+     *
+     * @param alertMsgCss   the CSS selector for the alert messages
+     * @return              a string of concatenated alert messages
+     */
+    private String grabAlertMessage(String alertMsgCss)
+    {
+        StringBuilder msgDisplay = new StringBuilder();
+        List<WebElement> alertMsgList = selenium_.findElements(By.cssSelector(alertMsgCss));
+        for (WebElement alertMsg : alertMsgList) {
+            msgDisplay.append(alertMsg.getText());
+        }
+        return msgDisplay.toString();
+    }
+
+    /**
      * Grabs all error messages displayed on the page.
      *
      * @return a string of concatenated error messages
      */
-	public String grabPageErrorMessage() {
-
-		String alertMsgCss = "span.ui-messages-error-summary";
-		StringBuilder msgDisplay = new StringBuilder();
-		List<WebElement> alertMsgList = selenium_.findElements(By.cssSelector(alertMsgCss));
-		for (WebElement alertMsg : alertMsgList) {
-			msgDisplay.append(alertMsg.getText());
-		}
-		return msgDisplay.toString();
-	}
+	public String grabPageErrorMessage() { return grabAlertMessage("span.ui-messages-error-summary"); }
 
     /**
      * Grabs all warning messages displayed on the page.
      *
      * @return a string of concatenated warning messages
      */
-	public String grabWarningErrorMessage() {
+	public String grabWarningErrorMessage() { return grabAlertMessage("span.ui-messages-warn-summary"); }
 
-		String alertMsgCss = "span.ui-messages-warn-summary";
-		StringBuilder msgDisplay = new StringBuilder();
-		List<WebElement> alertMsgList = selenium_.findElements(By.cssSelector(alertMsgCss));
-		for (WebElement alertMsg : alertMsgList) {
-			msgDisplay.append(alertMsg.getText());
-		}
-		return msgDisplay.toString();
-	}
+    /**
+     * Grabs all info messages displayed on the page.
+     *
+     * @return a string of concatenated info messages
+     */
+    public String grabInfoMessage() { return grabAlertMessage("span.ui-messages-info-summary"); }
 
 	/**
 	 * clear All Expertise

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/SearchProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/SearchProviderPage.java
@@ -491,7 +491,10 @@ extends BasicWebPage
         SearchProviderOrganizationFragment search = expandSearchOrganization(true);
         if (roleTypePrefix != null)
         {
-            search.selectRoleType(roleTypePrefix);
+            WebElement orgPanel = selenium_.findElement(By.id("accordian:searchByOrganizationForm:provider_identifier_panel"));
+            String currentRoleType = search.getRoleTypeMenu().grabSelectedItem();
+            if (!currentRoleType.equals(search.selectRoleType(roleTypePrefix)))
+                selenium_.waitUntil(ExpectedConditions.stalenessOf(orgPanel));
         }
         
 		if (name != null) {

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/SearchProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/SearchProviderPage.java
@@ -497,26 +497,7 @@ extends BasicWebPage
                 selenium_.waitUntil(ExpectedConditions.stalenessOf(orgPanel));
         }
         
-		if (name != null) {
-			search.fillName(name);
-		} else
-			search.clearName();
-		if (description != null) {
-			search.fillDescription(description);
-		} else
-			search.clearDescription();
-
-		if (addressLine1 != null) {
-			search.fillAddressLine1(addressLine1);
-		} else
-			search.clearAddressLine1();
-		if (city != null) {
-			search.fillCity(city);
-		} else
-			search.clearCity();
-		
-        search.clickSearchButton();
-        return waitForSearchProviderResultsFragment();
+        return fillCommonOrganizationFields(search, name, description, city, addressLine1);
     }
 
     /**
@@ -546,28 +527,35 @@ extends BasicWebPage
     
     	if(hdsType!=null)
          search.selectHdsType(hdsType);
-        
-		if (name != null) {
-			search.fillName(name);
-		} else
-			search.clearName();
-		if (description != null) {
-			search.fillDescription(description);
-		} else
-			search.clearDescription();
 
-		if (addressLine1 != null) {
-			search.fillAddressLine1(addressLine1);
-		} else
-			search.clearAddressLine1();
-		if (city != null) {
-			search.fillCity(city);
-		} else
-			search.clearCity();
-         
-         search.clickSearchButton();
-         return waitForSearchProviderResultsFragment();
-    	
+        return fillCommonOrganizationFields(search, name, description, city, addressLine1);
+    }
+
+    public SearchProviderResultsFragment fillCommonOrganizationFields(SearchProviderOrganizationFragment search,
+                                                                      String name,
+                                                                      String description,
+                                                                      String city,
+                                                                      String addressLine1) {
+        if (name != null) {
+            search.fillName(name);
+        } else
+            search.clearName();
+        if (description != null) {
+            search.fillDescription(description);
+        } else
+            search.clearDescription();
+
+        if (addressLine1 != null) {
+            search.fillAddressLine1(addressLine1);
+        } else
+            search.clearAddressLine1();
+        if (city != null) {
+            search.fillCity(city);
+        } else
+            search.clearCity();
+
+        search.clickSearchButton();
+        return waitForSearchProviderResultsFragment();
     }
 
     /**

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateOrganizationPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateOrganizationPage.java
@@ -4,6 +4,9 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
+import ca.bc.gov.health.qa.autotest.plr.web.tests.model.provider.IdType;
+import ca.bc.gov.health.qa.autotest.plr.web.tests.model.provider.OrgNameType;
+import ca.bc.gov.health.qa.autotest.plr.web.tests.model.provider.RegIdType;
 import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.ElementClickInterceptedException;
@@ -11,9 +14,7 @@ import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
-import ca.bc.gov.health.qa.autotest.plr.web.pages.components.DateMenu;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.components.DropDownMenu;
-import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.facility.FacilitySection;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.EndReason;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.OrganizationProperties;
 import ca.bc.gov.health.qa.autotest.runner.util.selenium.SeleniumExpectedConditions;
@@ -47,7 +48,7 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 	}
 
 	/**
-	 * Get Dialog Css selector for organization properties
+	 * Get Dialog CSS selector for organization properties
 	 *
 	 * @param section the provider section
 	 * @return string of dialog CSS selector
@@ -351,6 +352,118 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 	}
 
 	/**
+	 * Attempts to add a registry identifier data block with provided values
+	 * @param identifierType the identifier type
+	 * @param identifier the identifier value
+	 * @return the full message dialog of errors, if any exist. otherwise an empty string
+	 */
+	public String addRegistryIdentifierDataBlock(RegIdType identifierType, String identifier) {
+		String msgDisplay = "";
+		String formName = DIALOG_MAP.get(ProviderSection.REGISTRY_IDENTIFIERS).getFormName();
+		String dialogCss = getOrgDialogCss(ProviderSection.REGISTRY_IDENTIFIERS);
+
+		clickHeaderAddOrgPropertyButton(ProviderSection.REGISTRY_IDENTIFIERS);
+
+		// Wait for dialog to be visible and stable
+		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
+		waitSeconds(2);
+
+		// Set Identifier Type dropdown
+		setOrgDropdownListByVisibleText(ProviderSection.REGISTRY_IDENTIFIERS, "providerType", identifierType.getText());
+
+		// Set Identifier field
+		findAndFillOrgInputField(dialogCss, formName, identifier, "identifier");
+
+		clickOrgDialogSubmitButton(ProviderSection.REGISTRY_IDENTIFIERS);
+
+		msgDisplay = getDialogMessages(ProviderSection.REGISTRY_IDENTIFIERS);
+
+		if (!StringUtils.isEmpty(msgDisplay)) {
+			WebElement cancelButton = selenium_.findElement(By.linkText("Cancel"));
+			cancelButton.click();
+		}
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return msgDisplay;
+	}
+
+	/**
+	 * Attempts to add an identifier data block with provided values
+	 * @param identifierType the identifier type
+	 * @param identifier the identifier value
+	 * @return the full message dialog of errors, if any exist. otherwise an empty string
+	 */
+	public String addIdentifierDataBlock(IdType identifierType, String identifier) {
+		String msgDisplay = "";
+		String formName = DIALOG_MAP.get(ProviderSection.IDENTIFIERS).getFormName();
+		String dialogCss = getOrgDialogCss(ProviderSection.IDENTIFIERS);
+
+		clickHeaderAddOrgPropertyButton(ProviderSection.IDENTIFIERS);
+
+		// Wait for dialog to be visible and stable
+		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
+		waitSeconds(2);
+
+		// Set Identifier Type dropdown
+		setOrgDropdownListByVisibleText(ProviderSection.IDENTIFIERS, "providerType", identifierType.getText());
+
+		// Set Identifier field
+		findAndFillOrgInputField(dialogCss, formName, identifier, "identifier");
+
+		clickOrgDialogSubmitButton(ProviderSection.IDENTIFIERS);
+
+		msgDisplay = getDialogMessages(ProviderSection.IDENTIFIERS);
+
+		if (!StringUtils.isEmpty(msgDisplay)) {
+			WebElement cancelButton = selenium_.findElement(By.linkText("Cancel"));
+			cancelButton.click();
+		}
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return msgDisplay;
+	}
+
+	/**
+	 * Attempts to add an organization name data block with provided values
+	 * @param nameType the organization name type
+	 * @param name the organization name
+	 * @param description the organization description
+	 * @return the full message dialog of errors, if any exist. otherwise an empty string
+	 */
+	public String addOrganizationNameDataBlock(OrgNameType nameType, String name, String description) {
+		String msgDisplay = "";
+		String formName = DIALOG_MAP.get(ProviderSection.ORGANIZATION_NAMES).getFormName();
+		String dialogCss = getOrgDialogCss(ProviderSection.ORGANIZATION_NAMES);
+
+		clickHeaderAddOrgPropertyButton(ProviderSection.ORGANIZATION_NAMES);
+
+		// Wait for dialog to be visible and stable
+		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
+		waitSeconds(2);
+
+		// Set Name Type dropdown
+		setOrgDropdownListByVisibleText(ProviderSection.ORGANIZATION_NAMES, "type", nameType.getText());
+
+		// Set Name field
+		findAndFillOrgInputField(dialogCss, formName, name, "shortName");
+
+		// Set Description field
+		findAndFillOrgInputField(dialogCss, formName, description, "longName");
+
+		clickOrgDialogSubmitButton(ProviderSection.ORGANIZATION_NAMES);
+
+		msgDisplay = getDialogMessages(ProviderSection.ORGANIZATION_NAMES);
+
+		if (!StringUtils.isEmpty(msgDisplay)) {
+			WebElement cancelButton = selenium_.findElement(By.linkText("Cancel"));
+			cancelButton.click();
+		}
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return msgDisplay;
+	}
+
+	/**
 	 * Attempts to add an organization property data block with provided values
 	 *
 	 * @param propertyType the organization property type enum
@@ -400,6 +513,113 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 	 */
 	public String addOrganizationPropertyDataBlock(OrganizationProperties propertyType, String propertyValue) {
 		return addOrganizationPropertyDataBlock(propertyType, propertyValue, null, null);
+	}
+
+	/**
+	 * Attempts to update a registry identifier data block with provided values
+	 * @param identifier the identifier value
+	 * @param endReason the end reason to specify when updating
+	 * @param index the index of the data block to update
+	 * @param expectError whether an error is anticipated
+	 * @return a string of the error message, if expectError is true. otherwise an empty string
+	 */
+	public String updateRegistryIdentifierDataBlock(String identifier, EndReason endReason, int index, boolean expectError) {
+		String msgDisplay = "";
+		String formName = DIALOG_MAP.get(ProviderSection.REGISTRY_IDENTIFIERS).getFormName();
+		String dialogCss = getOrgDialogCss(ProviderSection.REGISTRY_IDENTIFIERS);
+
+		clickDataBlockUpdateButton(ProviderSection.REGISTRY_IDENTIFIERS, index);
+
+		// Wait for dialog to be visible and stable
+		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
+		waitSeconds(2);
+
+		// Set Identifier field
+		findAndFillOrgInputField(dialogCss, formName, identifier, "identifier");
+
+		if (endReason != null)
+			setOrgEndReasonByVisibleText(ProviderSection.REGISTRY_IDENTIFIERS, endReason.getText());
+
+		clickOrgDialogSubmitButton(ProviderSection.REGISTRY_IDENTIFIERS);
+
+		if (expectError)
+			msgDisplay = waitOrgErrorMessage(ProviderSection.REGISTRY_IDENTIFIERS);
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return msgDisplay;
+	}
+
+	/**
+	 * Attempts to update an identifier data block with provided values
+	 * @param identifier the identifier value
+	 * @param endReason the end reason to specify when updating
+	 * @param index the index of the data block to update
+	 * @param expectError whether an error is anticipated
+	 * @return a string of the error message, if expectError is true. otherwise an empty string
+	 */
+	public String updateIdentifierDataBlock(String identifier, EndReason endReason, int index, boolean expectError) {
+		String msgDisplay = "";
+		String formName = DIALOG_MAP.get(ProviderSection.IDENTIFIERS).getFormName();
+		String dialogCss = getOrgDialogCss(ProviderSection.IDENTIFIERS);
+
+		clickDataBlockUpdateButton(ProviderSection.IDENTIFIERS, index);
+
+		// Wait for dialog to be visible and stable
+		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
+		waitSeconds(2);
+
+		// Set Identifier field
+		findAndFillOrgInputField(dialogCss, formName, identifier, "identifier");
+
+		if (endReason != null)
+			setOrgEndReasonByVisibleText(ProviderSection.IDENTIFIERS, endReason.getText());
+
+		clickOrgDialogSubmitButton(ProviderSection.IDENTIFIERS);
+
+		if (expectError)
+			msgDisplay = waitOrgErrorMessage(ProviderSection.IDENTIFIERS);
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return msgDisplay;
+	}
+
+	/**
+	 * Attempts to update an organization name data block with provided values
+	 *
+	 * @param name the organization name
+	 * @param description the organization description
+	 * @param endReason the end reason to specify when updating
+	 * @param index the index of the data block to update
+	 * @param expectError whether an error is anticipated
+	 * @return a string of the error message, if expectError is true. otherwise an empty string
+	 */
+	public String updateOrganizationNameDataBlock(String name, String description, EndReason endReason, int index, boolean expectError) {
+		String msgDisplay = "";
+		String formName = DIALOG_MAP.get(ProviderSection.ORGANIZATION_NAMES).getFormName();
+		String dialogCss = getOrgDialogCss(ProviderSection.ORGANIZATION_NAMES);
+
+		clickDataBlockUpdateButton(ProviderSection.ORGANIZATION_NAMES, index);
+
+		// Wait for dialog to be visible and stable
+		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
+		waitSeconds(2);
+
+		// Set Name field
+		findAndFillOrgInputField(dialogCss, formName, name, "shortName");
+
+		// Set Description field
+		findAndFillOrgInputField(dialogCss, formName, description, "longName");
+
+		if (endReason != null)
+			setOrgEndReasonByVisibleText(ProviderSection.ORGANIZATION_NAMES, endReason.getText());
+
+		clickOrgDialogSubmitButton(ProviderSection.ORGANIZATION_NAMES);
+
+		if (expectError)
+			msgDisplay = waitOrgErrorMessage(ProviderSection.ORGANIZATION_NAMES);
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return msgDisplay;
 	}
 
 	/**

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -23,8 +23,14 @@ import ca.bc.gov.health.qa.autotest.runner.util.selenium.SeleniumSession;
 public class UpdateProviderPage extends ViewProviderPage {
 
 	public static final Map<ProviderSection, ProviderDialog> DIALOG_MAP = Map.of(
+			ProviderSection.REGISTRY_IDENTIFIERS, new ProviderDialog("maintainRegIdDialog", "maintainRegIdForm", "effectiveStartDate",
+					"effectiveEndDate", "registryIdSubmitButton", "EndReasonType","Add"),
 			ProviderSection.IDENTIFIERS, new ProviderDialog("maintainIdDialog", "maintainIdentifierForm", "effectiveFromDate",
-					"effectiveToDate", "idSubmitButton", "","Add"), 
+					"effectiveToDate", "idSubmitButton", "EndReasonType","Add"),
+			ProviderSection.ORGANIZATION_NAMES, new ProviderDialog("maintainOrgNameDialog", "maintainOrgNameForm", "effectiveStartDate",
+							"effectiveEndDate", "orgNameSubmitButton", "EndReasonType","Add a new Organizational Name"),
+			ProviderSection.PRACTITIONER_NAMES, new ProviderDialog("maintainPersonNameDialog", "maintainPersonNameForm", "effectiveStartDate",
+					"effectiveEndDate", "personNameSubmitButton", "EndReasonType","Add a new Practitioner Name"),
 			ProviderSection.NOTES, new ProviderDialog("maintainNoteDialog", "maintainNoteForm", "effectiveFromDate",
 					"effectiveToDate", "idNoteSubmitButton", "endReasonCode","Add a new Note"),
 			ProviderSection.ORGANIZATION_RELATIONSHIPS, new ProviderDialog("maintainOrganizationRelationshipDialog", "maintainOrgRelationshipForm", "effectiveStartDate",
@@ -65,6 +71,54 @@ public class UpdateProviderPage extends ViewProviderPage {
 		} catch (InterruptedException e) {
 			fail(e.getMessage());
 		}
+	}
+
+	/**
+	 * Attempts to update a practitioner name data block with provided values
+	 * @param prefix the name prefix
+	 * @param first the first name
+	 * @param second the second name
+	 * @param third the third name
+	 * @param surname the surname
+	 * @param suffix the name suffix
+	 * @param endReasonType the end reason type
+	 * @param index the data block index
+	 * @param expectError whether an error is expected
+	 * @return the error message if expectError is true, otherwise an empty string
+	 */
+	public String updatePractitionerNameDataBlock(
+			String prefix, String first, String second, String third, String surname, String suffix,
+			EndReason endReasonType, int index, boolean expectError)
+	{
+		String msgDisplay = "";
+		String formName = DIALOG_MAP.get(ProviderSection.PRACTITIONER_NAMES).getFormName();
+		String dialogCss = getDialogCss(ProviderSection.PRACTITIONER_NAMES);
+
+		clickDataBlockUpdateButton(ProviderSection.PRACTITIONER_NAMES, index);
+
+		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
+		waitSeconds(2);
+
+		findAndFillInputField(dialogCss, formName, prefix, "prefix");
+		findAndFillInputField(dialogCss, formName, first, "firstName");
+		findAndFillInputField(dialogCss, formName, second, "secondName");
+		findAndFillInputField(dialogCss, formName, third, "thirdName");
+		findAndFillInputField(dialogCss, formName, surname, "surname");
+		findAndFillInputField(dialogCss, formName, suffix, "suffix");
+
+		if (endReasonType != null) {
+			setEndReasonByVisibleText(ProviderSection.PRACTITIONER_NAMES, endReasonType.getText());
+		}
+
+		clickDialogSubmitButton(ProviderSection.PRACTITIONER_NAMES, expectError);
+
+		if (expectError) {
+			msgDisplay = waitErrorMessage(ProviderSection.PRACTITIONER_NAMES);
+		} else {
+			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		}
+
+		return msgDisplay;
 	}
 
 	/**
@@ -240,6 +294,23 @@ public class UpdateProviderPage extends ViewProviderPage {
 		}
 		
 		return msgDisplay.trim();
+	}
+
+	/**
+	 * Find And Fill an input field for organization properties (TEXT_FIELD type)
+	 *
+	 * @param dialogCss the dialog CSS selector
+	 * @param formName the form name
+	 * @param field the field value
+	 * @param fieldCss the field CSS selector
+	 */
+	private void findAndFillInputField(String dialogCss, String formName, String field, String fieldCss) {
+		String inputNameCss = dialogCss + " >input#" + formName + "\\:" + fieldCss;
+		// Wait for the input field to be visible
+		WebElement inputName = selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(inputNameCss)));
+		inputName.clear();
+		if (!StringUtils.isEmpty(field))
+			inputName.sendKeys(field);
 	}
 
 	/**

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/ViewProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/ViewProviderPage.java
@@ -9,8 +9,6 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.ViewHeaderFragment;
-import ca.bc.gov.health.qa.autotest.runner.util.log.ExecutionLogManager;
-import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -25,8 +23,6 @@ import ca.bc.gov.health.qa.autotest.runner.util.selenium.pages.BasicWebPage;
 public class ViewProviderPage
 extends BasicWebPage
 {
-    private static final Logger LOG = ExecutionLogManager.getLogger();
-
     private static final Pattern DATA_KEY_SUFFIX_PATTERN = Pattern.compile(":$");
 
     private final ViewHeaderFragment viewHeader_;

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/TestHelper.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/TestHelper.java
@@ -27,12 +27,10 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 import static java.util.Objects.requireNonNull;
-import java.util.ArrayList;
+
+import java.util.*;
 import java.security.SecureRandom;
 import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -433,5 +431,22 @@ public final class TestHelper {
         boolean isOrg = !Objects.isNull(orgBuilder);
 
         return isOrg ? orgBuilder.getIdentifier(ipc) : indBuilder.getIdentifier(ipc);
+    }
+
+    /**
+     * get Random Number
+     * @param min	the min number
+     * @param max 	the max number
+     * @return 		random number between min and max
+     */
+    public static int getRandomNumber(int min, int max) {
+        // Create a Random object
+        Random random = new Random();
+
+        // Generate the random number
+        // nextInt((max - min) + 1) generates a number between 0 and 4
+        // Adding min (2) shifts the range to be between 2 and 6 (exclusive of 6)
+        return random.nextInt((max - min) + 1) + min;
+
     }
 }

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/TestHelper.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/TestHelper.java
@@ -10,10 +10,7 @@ import ca.bc.gov.health.qa.autotest.plr.util.UserType;
 import ca.bc.gov.health.qa.autotest.plr.web.actions.provider.ViewProviderActions;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.facility.add.AddFacilityAddressFragment;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.facility.add.AddFacilityPage;
-import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.SearchProviderPage;
-import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.SearchProviderResultsFragment;
-import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.UpdateOrganizationPage;
-import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.ViewProviderPage;
+import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.*;
 import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflow;
 import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflowManager;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.facility.search.SearchFacilityPage;
@@ -427,6 +424,18 @@ public final class TestHelper {
         search.openResults(0);
         
         return new UpdateOrganizationPage(workflow.getSeleniumSession(), 
+                                        workflow.getURUri().resolve("/plr/ProviderDetails.xhtml"));
+    }
+
+    public static UpdateProviderPage viewByIdentifierAsUpdateIndividual(String identifier, PlrWebWorkflowManager workflowManager) {
+        final PlrWebWorkflow workflow = workflowManager.getSelectedWorkflow();
+
+        SearchProviderPage searchProviderPage = workflow.getPlrWebAccessActions().openSearchProvider();
+        SearchProviderResultsFragment search = searchProviderPage.searchByIdentifier(
+                "IPC", identifier);
+        search.openResults(0);
+
+        return new UpdateProviderPage(workflow.getSeleniumSession(),
                                         workflow.getURUri().resolve("/plr/ProviderDetails.xhtml"));
     }
 

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/facility/CreateFacilitySimpleTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/facility/CreateFacilitySimpleTests.java
@@ -40,6 +40,7 @@ import java.util.List;
 import static ca.bc.gov.health.qa.autotest.plr.web.tests.TestHelper.navigateToAddFacilityPage;
 import static org.testng.Assert.*;
 
+/** Tests class (simple) for the Create Facility page */
 public class CreateFacilitySimpleTests implements SimpleTest {
 
     private final PlrWebWorkflowManager workflowManager_ = new PlrWebWorkflowManager();
@@ -51,7 +52,7 @@ public class CreateFacilitySimpleTests implements SimpleTest {
     private static FacilityBuilderFactory facilityDataGen;
     private static final Logger LOG = ExecutionLogManager.getLogger();
 
-    public CreateFacilitySimpleTests()
+    private CreateFacilitySimpleTests()
     {
         try
         {
@@ -68,14 +69,14 @@ public class CreateFacilitySimpleTests implements SimpleTest {
     }
 
     @BeforeMethod
-    public void before(Object[] parameters)
+    private void before(Object[] parameters)
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(parameters, UserType.ADMIN);
         if (!workflow.isLoggedIn()) workflow.login().openPlr();
     }
 
     @AfterClass
-    public void teardown() {
+    private void teardown() {
         workflowManager_.logoutAllAndClose();
         LOG.info("Done.");
     }

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/facility/UpdateFacilitySimpleSetTwoTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/facility/UpdateFacilitySimpleSetTwoTests.java
@@ -22,24 +22,23 @@ import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflowManager;
 import ca.bc.gov.health.qa.autotest.runner.util.log.ExecutionLogManager;
 import ca.bc.gov.health.qa.autotest.runner.util.testng.SimpleTest;
 
+/** Tests class (simple) for the second set of Update Facility menus */
 public class UpdateFacilitySimpleSetTwoTests implements SimpleTest {
 	private static final Logger LOG = ExecutionLogManager.getLogger();
 
 	private final PlrWebWorkflowManager workflowManager_ = new PlrWebWorkflowManager();
 	private MaintainFacilityBuilder facility;
 
-	public UpdateFacilitySimpleSetTwoTests() {
-
-	}
+	private UpdateFacilitySimpleSetTwoTests() {}
 
 	@AfterClass
-	public void teardown() {
+	private void teardown() {
 		workflowManager_.logoutAllAndClose();
 		LOG.info("Done.");
 	}
 
 	@BeforeMethod
-	public void before(Object[] parameters) {
+	private void before(Object[] parameters) {
 
 		PlrWebWorkflow workflow = workflowManager_.selectWorkflow(parameters, UserType.ADMIN);
 		if (!workflow.isLoggedIn()) {

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/facility/UpdateFacilitySimpleTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/facility/UpdateFacilitySimpleTests.java
@@ -20,6 +20,7 @@ import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflowManager;
 import ca.bc.gov.health.qa.autotest.runner.util.log.ExecutionLogManager;
 import ca.bc.gov.health.qa.autotest.runner.util.testng.SimpleTest;
 
+/** Tests class (simple) for the first set of Update Facility menus */
 public class UpdateFacilitySimpleTests implements SimpleTest {
 	private static final Logger LOG = ExecutionLogManager.getLogger();
 

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/facility/ViewFacilitySimpleTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/facility/ViewFacilitySimpleTests.java
@@ -1,11 +1,10 @@
-package ca.bc.gov.health.qa.autotest.plr.web.tests;
+package ca.bc.gov.health.qa.autotest.plr.web.tests.facility;
 
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.util.*;
 
-import ca.bc.gov.health.qa.autotest.plr.data.ViewFacilityConstants.*;
 import ca.bc.gov.health.qa.autotest.plr.fhir.FHIRController;
 import ca.bc.gov.health.qa.autotest.plr.fhir.data.facility.FacilityMaintainConfig;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.facility.MaintainFacilityBuilder;

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/facility/ViewFacilitySimpleTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/facility/ViewFacilitySimpleTests.java
@@ -42,7 +42,7 @@ public class ViewFacilitySimpleTests implements SimpleTest {
 	public ViewFacilitySimpleTests() {}
 
 	@AfterClass
-	public void teardown() {
+	private void teardown() {
 		dummyFacility.ceaseOrganizationRelationships();
 		fhirController.close();
 
@@ -51,7 +51,7 @@ public class ViewFacilitySimpleTests implements SimpleTest {
 	}
 
 	@BeforeTest
-	public void beforeTest()
+	private void beforeTest()
 	{
 		fhirController = new FHIRController(UserType.ADMIN);
 
@@ -63,7 +63,7 @@ public class ViewFacilitySimpleTests implements SimpleTest {
 	}
 
 	@BeforeMethod
-	public void before(Object[] parameters) {
+	private void before(Object[] parameters) {
 		 PlrWebWorkflow workflow = workflowManager_.selectWorkflow(parameters, UserType.ADMIN);
 		 if (!workflow.isLoggedIn()) workflow.login().openPlr();
 	}

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/ElectronicAddressType.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/ElectronicAddressType.java
@@ -1,8 +1,14 @@
 package ca.bc.gov.health.qa.autotest.plr.web.tests.model;
 
+/**
+ * Enum for Electronic Address Types
+ */
 public enum ElectronicAddressType {
-	EMAIL("E - Email"), 
+	/** Email */
+	EMAIL("E - Email"),
+	/** FTP */
 	FTP("F - FTP"),
+	/** HTTP */
 	HTTP("H - HTTP");
 
 	private final String text;
@@ -11,16 +17,41 @@ public enum ElectronicAddressType {
 		this.text = text;
 	}
 
+	/**
+	 * Get the text value of the enum
+	 * @return the text value as a string
+	 */
 	public String getText() {
 		return this.text;
 	}
 
+	/**
+	 * Get the starting text before the hyphen
+	 *
+	 * @return the starting text as a string
+	 */
 	public String getStartText() { return this.text.split(" ")[0]; }
 
+	/**
+	 * Get the ending text after the hyphen
+	 *
+	 * @return the ending text as a string
+	 */
 	public String getEndText() { return this.text.split(" ")[2]; }
 
+	/**
+	 * Get the data field format "EndText (StartText)"
+	 *
+	 * @return the data field as a string
+	 */
 	public String getDataField() { return this.getEndText() + " (" + this.getStartText() + ")"; }
 
+	/**
+	 * Get the enum from a string value
+	 *
+	 * @param text  the string value
+	 * @return 		the corresponding enum, or null if not found
+	 */
 	public static ElectronicAddressType fromString(String text) {
 		for (ElectronicAddressType b : ElectronicAddressType.values()) {
 			if (b.text.equalsIgnoreCase(text)) {

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/EndReason.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/EndReason.java
@@ -3,13 +3,13 @@ package ca.bc.gov.health.qa.autotest.plr.web.tests.model;
 /**
  * Enumerates end reasons used for relationship/status termination.
  */
-
 public enum EndReason {
-	
-	
-	 CEASE("CEASE - Cease"), 
-	 CHG("CHG - Change"),
-	 CORR("CORR - Correct");
+	/** Cease */
+	CEASE("CEASE - Cease"),
+	/** Change */
+	CHG("CHG - Change"),
+	/** Correct */
+	CORR("CORR - Correct");
 
 	private String text;
 

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/GenderCode.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/GenderCode.java
@@ -4,9 +4,12 @@ package ca.bc.gov.health.qa.autotest.plr.web.tests.model;
  * Enumerates gender codes used in the system.
  */
 public enum GenderCode {
-	 U("U - Unknown"), 
-	 F("F - Female"),
-	 M("M - Male");
+	/** Unknown */
+	U("U - Unknown"),
+	/** Female */
+	F("F - Female"),
+	/** Male */
+	M("M - Male");
 
 	private String text;
 

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/HdsType.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/HdsType.java
@@ -4,14 +4,23 @@ package ca.bc.gov.health.qa.autotest.plr.web.tests.model;
  * Enum representing different types of Health Delivery Services (HDS).
  */
 public enum HdsType {
-	CLINIC("CLINIC - Clinic"), 
+	/** Clinic */
+	CLINIC("CLINIC - Clinic"),
+	/** Pharmacy */
 	PHARMACY("PHARMACY - Pharmacy"),
+	/** Hospital */
 	HOSPITAL("HOSPITAL - Hospital"),
+	/** Emergency */
 	EMERGENCY("EMERGENCY - Emergency"),
+	/** Laboratory */
 	LAB("LAB - Laboratory"),
+	/** General Care */
 	GENERAL_CARE("GENERAL_CARE - General Care"),
+	/** Inpatient */
 	INPATIENT("INPATIENT - Inpatient"),
+	/** Housing */
 	HOUSING("HOUSING - Housing"),
+	/** Outpatient */
 	OUTPATIENT("OUTPATIENT - Outpatient");
 	
 	private String text;

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/IdentifierTypeName.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/IdentifierTypeName.java
@@ -1,7 +1,12 @@
 package ca.bc.gov.health.qa.autotest.plr.web.tests.model;
 
+/**
+ * Enum representing different types of Identifier Type Names.
+ */
 public enum IdentifierTypeName {
+	/** Select One */
 	SELECT_ONE("Select One"),
+	/** Internal Facility Code */
 	IFC("IFC - Internal Facility Code");
 
 	private final String text;
@@ -10,10 +15,21 @@ public enum IdentifierTypeName {
 		this.text = text;
 	}
 
+	/**
+	 * Gets the text representation of the identifier type name.
+	 *
+	 * @return the text representation
+	 */
 	public String getText() {
 		return this.text;
 	}
 
+	/**
+	 * Converts a string to the corresponding IdentifierTypeName enum value.
+	 *
+	 * @param text  the string representation of the identifier type name
+	 * @return 		the corresponding IdentifierTypeName enum value, or null if not found
+	 */
 	public static IdentifierTypeName fromString(String text) {
 		for (IdentifierTypeName b : IdentifierTypeName.values()) {
 			if (b.text.equalsIgnoreCase(text)) {

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/OrganizationalProviderRoleType.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/OrganizationalProviderRoleType.java
@@ -5,9 +5,13 @@ package ca.bc.gov.health.qa.autotest.plr.web.tests.model;
  */
 public enum OrganizationalProviderRoleType {
 
-	ORG("ORG - Organization"), 
+	/** Organization */
+	ORG("ORG - Organization"),
+	/** Healthcare Delivery Site */
 	HDS("HDS - Healthcare Delivery Site"),
+	/** Clinic */
 	CLINIC("CLINIC - Clinic"),
+	/** Business - Corporation */
 	BUSINESS("BUSINESS - Corporation");	
 
 	private String text;

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/ProviderRoleType.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/ProviderRoleType.java
@@ -4,38 +4,70 @@ package ca.bc.gov.health.qa.autotest.plr.web.tests.model;
  * Enum representing different types of Provider Roles.
  */
 public enum ProviderRoleType {
-	
-	DEN("DEN - Dentist"), 
-	MD("MD - Medical Doctor"), 
-	RN("RN - Registered Nurse"), 
-	RNP("RNP - Registered Nurse Practitioner"), 
-	OOPMD("OOP-MD - OOP Medical Doctor"), 
-	OOPDEN("OOP-DEN - OOP Dentist"), 
-	OOPRN("OOP-RN - OOP Registered Nurse"), 
-	OOPRNP("OOP-RNP - OOP Registered Nurse Practitione"), 
-	OOPPHARM("OOP-PHARM - OOP Pharmacist"), 
-	OOPOPT("OOP-OPT - OOP Optometris"), 
-	OPT("OPT - Optometrist"), 
-	RPN("RPN - Registered Psychiatric Nurse"), 
-	OOPRM("OOP-RM - OOP Registered Midwife"), 
-	LPN("LPN - Licensed Practical Nurse"), 
-	RM("RM - Registered Midwife"), 
-	PHARM("PHARM - Pharmacist"), 
-	PO("PO - Podiatrist"), 
-	HA("HA - Health Authority"), 
-	OOPND("OOP-ND - OOP Naturopathic Doctor"), 
-	OOPAUD("OOP-AUD - OOP Audiologist"), 
-	OOPSW("OOP-SW - OOP Social Worker"), 
-	OOPRECT("OOP-RECT - OOP Recreation Therapist"), 
-	OOPRT("OOP-RT - OOP Respiratory Therapist"), 
-	OOPRD("OOP-RD - OOP Registered Dietician"), 
-	OOPOT("OOP-OT - OOP Occupational Therapist"), 
-	OOPCC("OOP-CC - OOP Registered Clinical Counsellor"), 
+
+	/** Dentist */
+	DEN("DEN - Dentist"),
+	/** Medical Doctor */
+	MD("MD - Medical Doctor"),
+	/** Registered Nurse */
+	RN("RN - Registered Nurse"),
+	/** Registered Nurse Practitioner */
+	RNP("RNP - Registered Nurse Practitioner"),
+	/** Out of Province Medical Doctor */
+	OOPMD("OOP-MD - OOP Medical Doctor"),
+	/** Out of Province Dentist */
+	OOPDEN("OOP-DEN - OOP Dentist"),
+	/** Out of Province Registered Nurse */
+	OOPRN("OOP-RN - OOP Registered Nurse"),
+	/** Out of Province Registered Nurse Practitioner */
+	OOPRNP("OOP-RNP - OOP Registered Nurse Practitione"),
+	/** Out of Province Pharmacist */
+	OOPPHARM("OOP-PHARM - OOP Pharmacist"),
+	/** Out of Province Optometrist */
+	OOPOPT("OOP-OPT - OOP Optometris"),
+	/** Optometrist */
+	OPT("OPT - Optometrist"),
+	/** Registered Psychiatric Nurse */
+	RPN("RPN - Registered Psychiatric Nurse"),
+	/** Out of Province Registered Midwife */
+	OOPRM("OOP-RM - OOP Registered Midwife"),
+	/** Licensed Practical Nurse */
+	LPN("LPN - Licensed Practical Nurse"),
+	/** Registered Midwife */
+	RM("RM - Registered Midwife"),
+	/** Pharmacist */
+	PHARM("PHARM - Pharmacist"),
+	/** Podiatrist */
+	PO("PO - Podiatrist"),
+	/** Health Authority */
+	HA("HA - Health Authority"),
+	/** Out of Province Naturopathic Doctor */
+	OOPND("OOP-ND - OOP Naturopathic Doctor"),
+	/** Out of Province Audiologist */
+	OOPAUD("OOP-AUD - OOP Audiologist"),
+	/** Out of Province Social Worker */
+	OOPSW("OOP-SW - OOP Social Worker"),
+	/** Out of Province Recreation Therapist */
+	OOPRECT("OOP-RECT - OOP Recreation Therapist"),
+	/** Out of Province Respiratory Therapist */
+	OOPRT("OOP-RT - OOP Respiratory Therapist"),
+	/** Out of Province Registered Dietician */
+	OOPRD("OOP-RD - OOP Registered Dietician"),
+	/** Out of Province Occupational Therapist */
+	OOPOT("OOP-OT - OOP Occupational Therapist"),
+	/** Out of Province Registered Clinical Counsellor */
+	OOPCC("OOP-CC - OOP Registered Clinical Counsellor"),
+	/** Out of Province Speech Language Pathologist */
 	OOPSLP("OOP-SLP - OOP Speech Language Pathologist"),
+	/** Out of Province Podiatrist */
 	OOPPO("OOP-PO - OOP Podiatrist"),
+	/** Out of Province Chiropractor */
 	OOPCHIRO("OOP-CHIRO - OOP Chiropractor"),
+	/** Out of Province Physical Therapist */
 	OOPPT("OOP-PT - OOP Physical Therapist"),
+	/** Out of Province Vocational Counsellor */
 	OOPVC("OOP-VC - OOP Vocational Counsellor"),
+	/** Out of Province Psychologist */
 	OOPPSYCH("OOP-PSYCH - OOP Psychologist");
 	
 

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/RelationshipType.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/RelationshipType.java
@@ -1,8 +1,11 @@
 package ca.bc.gov.health.qa.autotest.plr.web.tests.model;
 
+/** Enum representing different types of Organization/Facility Relationships. */
 public enum RelationshipType {
-	
+
+	/** Location of */
 	LOCATION("LOCATION - Location of", "Location of (LOCATION)"),
+	/** Located at */
 	LOCATED("LOCATED - Located at", "Located at (LOCATED)");
 	 
 

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/StatusCodeOption.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/StatusCodeOption.java
@@ -4,13 +4,21 @@ package ca.bc.gov.health.qa.autotest.plr.web.tests.model;
  * Enum representing different status codes.
  */
 public enum StatusCodeOption {
-	CANCELLED("CANCELLED - Cancelled"), 
-	ACTIVE("ACTIVE - Active"), 
-	TERMINATED("TERMINATED - Terminated"), 
-	INACTIVE("INACTIVE - Inactive"), 
-	SUSPENDED("SUSPENDED - Suspended"), 
+	/** Cancelled */
+	CANCELLED("CANCELLED - Cancelled"),
+	/** Active */
+	ACTIVE("ACTIVE - Active"),
+	/** Terminated */
+	TERMINATED("TERMINATED - Terminated"),
+	/** Inactive */
+	INACTIVE("INACTIVE - Inactive"),
+	/** Suspended */
+	SUSPENDED("SUSPENDED - Suspended"),
+	/** Nullified */
 	NULLIFIED("NULLIFIED - Nullified"),
+	/** Pending */
 	PENDING("PENDING - Pending"),
+	/** Unknown */
 	UNKNOWN("UNKNOWN - Unknown");
 
 	private String text;

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/StatusReasonCodeOption.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/StatusReasonCodeOption.java
@@ -4,32 +4,59 @@ package ca.bc.gov.health.qa.autotest.plr.web.tests.model;
  * Enum representing different status reason codes.
  */
 public enum StatusReasonCodeOption {
-	RET("RET - Retired"), 
+	/** Retired */
+	RET("RET - Retired"),
+	/** Practising */
 	PRAC("PRAC - Practising"),
+	/** Voluntary Withdrawal */
 	VW("VW - Voluntary Withdrawal"),
+	/** Non-resident */
 	NR("NR - Non-resident"),
+	/** Temporary Permit */
 	TEMPPER("VW - Temporary Permit"),
+	/** Organization Provider */
 	ORG("ORG - Organization Provider"),
+	/** Initial Non Practicing */
 	INNONPRAC("INNONPRAC - Initial Non Practicing"),
+	/** Left the Province */
 	LTP("LTP - Left the Province"),
+	/** Special Registry */
 	SPE("SPE - Special Registry"),
+	/** Associate */
 	ASSOC("ASSOC - Associate"),
+	/** Erased by Resolution */
 	ERSRES("ERSRES - Erased by Resolution"),
+	/** Unknown */
 	UNK("UNK - Unknown"),
+	/** Deceased */
 	DEC("DEC - Deceased"),
+	/** Honorary */
 	HON("HON - Honorary"),
+	/** Transfer */
 	TSF("TSF - Transfer"),
+	/** Licensed Denied */
 	DEN("DEN - Licensed Denied"),
+	/** Good Standing */
 	GS("GS - Good Standing"),
+	/** Non Payment of Fee */
 	NONPAY("NONPAY - Non Payment of Fee"),
+	/** Suspended */
 	SUS("SUS - Suspended"),
+	/** Out of Province */
 	OOP("OOP - Out of Province"),
+	/** Address Unknown */
 	AU("AU - Address Unknown"),
+	/** Non Practicing */
 	NONPRAC("NONPRAC - Non Practicing"),
+	/** Temporary Inactive */
 	TI("TI - Temporary Inactive"),
+	/** Missionary */
 	MIS("MIS - Missionary"),
+	/** License Lapsed on Request */
 	LAP("LAP - License Lapsed on Request"),
+	/** Resigned - disciplinary action */
 	RESDISC("RESDISC - Resigned - disciplinary action"),
+	/** Medical Student */
 	MEDSTUD("MEDSTUD - Medical Student");
 
 	private String text;

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/TelecommunicationType.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/TelecommunicationType.java
@@ -1,10 +1,18 @@
 package ca.bc.gov.health.qa.autotest.plr.web.tests.model;
 
+/**
+ * Enum representing different types of telecommunication methods.
+ */
 public enum TelecommunicationType {
-	PHONE("T - Telephone"), 
+	/** Telephone */
+	PHONE("T - Telephone"),
+	/** Mobile */
 	MOBILE("MB - Mobile"),
+	/** Pager */
 	PAGER("PG - Pager"),
+	/** Fax */
 	FAX("FAX - Fax"),
+	/** Modem */
 	MODEM("M - Modem");
 
 	private final String text;
@@ -13,16 +21,42 @@ public enum TelecommunicationType {
 		this.text = text;
 	}
 
+	/**
+	 * Gets the text representation of the telecommunication type.
+	 *
+	 * @return the text representation
+	 */
 	public String getText() {
 		return this.text;
 	}
 
+	/**
+	 * Gets the starting part of the text representation.
+	 *
+	 * @return the starting part as a string
+	 */
 	public String getStartText() { return this.text.split(" ")[0]; }
 
+	/**
+	 * Gets the ending part of the text representation.
+	 *
+	 * @return the ending part as a string
+	 */
 	public String getEndText() { return this.text.split(" ")[2]; }
 
+	/**
+	 * Gets a formatted data field combining the end and start text (e.g., "Telephone (T)").
+	 *
+	 * @return the formatted data field
+	 */
 	public String getDataField() { return this.getEndText() + " (" + this.getStartText() + ")"; }
 
+	/**
+	 * Converts a string to the corresponding TelecommunicationType enum value.
+	 *
+	 * @param text  the string representation
+	 * @return 		the corresponding TelecommunicationType, or null if not found
+	 */
 	public static TelecommunicationType fromString(String text) {
 		for (TelecommunicationType b : TelecommunicationType.values()) {
 			if (b.text.equalsIgnoreCase(text)) {

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/provider/IdType.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/provider/IdType.java
@@ -1,0 +1,41 @@
+package ca.bc.gov.health.qa.autotest.plr.web.tests.model.provider;
+
+/**
+ * Enumeration for ID Types
+ */
+public enum IdType {
+    /** Common Party Number */
+    CPN("CPN - Common Party Number"),
+    /** Internal Provider Code */
+    IPC("IPC - Internal Provider Code"),
+    /** Organization ID */
+    ORGID("ORGID - Organization");
+
+    private final String text;
+
+    IdType(String text) {
+        this.text = text;
+    }
+
+    /**
+     * Get the text representation of the IdType
+     * @return the text
+     */
+    public String getText() {
+        return this.text;
+    }
+
+    /**
+     * Get IdType from string
+     * @param text string value
+     * @return IdType enum
+     */
+    public static IdType fromString(String text) {
+        for (IdType b : IdType.values()) {
+            if (b.text.equalsIgnoreCase(text)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("No constant with text " + text + " found");
+    }
+}

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/provider/OrgNameType.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/provider/OrgNameType.java
@@ -1,0 +1,35 @@
+package ca.bc.gov.health.qa.autotest.plr.web.tests.model.provider;
+
+/**
+ * Enumeration for Organization Name Types
+ */
+public enum OrgNameType {
+    /** Current Known Name */
+    CURR("CURR - Current Known Name"),
+    /** Credential Name */
+    CRED("CRED - Credential Name");
+
+    private final String text;
+
+    OrgNameType(String text) { this.text = text; }
+
+    /**
+     * Get the text representation of the OrgNameType
+     * @return the text
+     */
+    public String getText() { return text; }
+
+    /**
+     * Get OrgNameType from text
+     * @param text the text
+     * @return the OrgNameType
+     */
+    public static OrgNameType fromText(String text) {
+        for (OrgNameType type : OrgNameType.values()) {
+            if (type.getText().equals(text)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("No OrgNameType with text: " + text);
+    }
+}

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/provider/RegIdType.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/provider/RegIdType.java
@@ -1,0 +1,35 @@
+package ca.bc.gov.health.qa.autotest.plr.web.tests.model.provider;
+
+/**
+ * Enumeration for Registry ID Types
+ */
+public enum RegIdType {
+    /** Common Provider Number */
+    CPN("CPN - Common Provider NUMBER"),
+    /** Internal Provider Code */
+    IPC("IPC - Internal Provider ID");
+
+    private final String text;
+
+    RegIdType(String text) { this.text = text; }
+
+    /**
+     * Get registry ID enum text
+     * @return string value
+     */
+    public String getText() { return this.text; }
+
+    /**
+     * Get registry ID enu, from string
+     * @param text string value
+     * @return RegIdType enum
+     */
+    public static RegIdType fromString(String text) {
+        for (RegIdType b : RegIdType.values()) {
+            if (b.text.equalsIgnoreCase(text)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("No constant with text " + text + " found");
+    }
+}

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
@@ -83,7 +83,7 @@ public class SearchProviderTests implements SimpleTest {
 	@AfterClass
 	private void teardown() {
 		fhirController.close();
-		//workflowManager_.logoutAllAndClose();
+		workflowManager_.logoutAllAndClose();
 		LOG.info("Done.");
 	}
 
@@ -330,7 +330,7 @@ public class SearchProviderTests implements SimpleTest {
 		}
 
 		// Test Start
-		ViewProviderPage page = actions.openConfidentialRecord(workflow, isOrganization, confOrg, confInd);
+		ViewProviderPage page = actions.openConfidentialRecord(workflow, UserType.SECONDARY, isOrganization, confOrg, confInd);
 
 		// Verify confidential sections are masked
 		for (ProviderSection section : ProviderSection.getProviderSectionSet(providerType))
@@ -864,7 +864,7 @@ public class SearchProviderTests implements SimpleTest {
 			if (!workflow.isLoggedIn()) { workflow.login().openPlr(); }
 			final SearchProviderActions actions = workflowManager_.getSelectedWorkflow().getSearchProviderActions();
 
-			ViewProviderPage page = actions.openConfidentialRecord(workflow, isOrganization, confOrg, confInd);
+			ViewProviderPage page = actions.openConfidentialRecord(workflow, userType, isOrganization, confOrg, confInd);
 
 			for (ProviderSection section : ProviderSection.getProviderSectionSet(providerType))
 			{

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
@@ -1,5 +1,6 @@
 package ca.bc.gov.health.qa.autotest.plr.web.tests.provider;
 
+import static ca.bc.gov.health.qa.autotest.plr.web.tests.TestHelper.getRandomNumber;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -11,10 +12,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.query.OrgQueryCriteriaParams;
+import ca.bc.gov.health.qa.autotest.plr.web.actions.provider.SearchProviderActions;
+import ca.bc.gov.health.qa.autotest.plr.web.pages.common.AlertMessagesFragment;
+import ca.bc.gov.health.qa.autotest.plr.web.tests.TestHelper;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Ordering;
@@ -50,6 +56,8 @@ public class SearchProviderTests implements SimpleTest {
 	private static final Config config_ = ConfigProvider.get().getConfig();
     private static final Path errorPath = Path.of(config_.get("data.dir")).resolve("error-list.json");
     private static JSONObject errorList,warningList;
+
+	private static FHIRController fhirController;
     
 	private SearchProviderTests() {
 		
@@ -81,7 +89,11 @@ public class SearchProviderTests implements SimpleTest {
 		if (!workflow.isLoggedIn()) {
 			workflow.login().openPlr();
 		}
+	}
 
+	@BeforeTest
+	public void beforeTest() {
+		fhirController = new FHIRController(UserType.ADMIN);
 	}
 
 	// Case Insensitive Search
@@ -91,7 +103,6 @@ public class SearchProviderTests implements SimpleTest {
 		PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
 		SearchProviderPage searchProviderPage = workflow.getPlrWebAccessActions().openSearchProvider();
 		// FHIR
-		FHIRController fhirController = new FHIRController(UserType.ADMIN);
 		IndividualBuilderFactory individualFactory = new IndividualBuilderFactory(
 				IndividualDataGenerator.getInstance());
 
@@ -123,7 +134,6 @@ public class SearchProviderTests implements SimpleTest {
         assertEquals(lowerCaseSearch, mixedCaseSearch, "The search results are not equal");
 
 		// FHIR-organization
-		fhirController = new FHIRController(UserType.ADMIN);
 		OrganizationMaintainConfig orgConfig = new OrganizationMaintainConfig(OrgRoleType.ORG).withAlias();
 		MaintainOrgBuilder org = fhirController.createOrganization(orgConfig);
 		MaintainOrgBuilder orgQueried = fhirController.queryOrganizationByIdentifier(IdentifierType.IPC,
@@ -156,7 +166,6 @@ public class SearchProviderTests implements SimpleTest {
 		PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
 		SearchProviderPage searchProvider = workflow.getPlrWebAccessActions().openSearchProvider();
 		// FHIR
-		FHIRController fhirController = new FHIRController(UserType.ADMIN);
 		IndividualBuilderFactory individualFactory = new IndividualBuilderFactory(
 				IndividualDataGenerator.getInstance());
 
@@ -187,7 +196,6 @@ public class SearchProviderTests implements SimpleTest {
 		assertTrue(searchResults.grabResultsRowCount() > 0, "search result has too less rows");
 
 		// FHOR - organization
-		fhirController = new FHIRController(UserType.ADMIN);
 		OrganizationMaintainConfig orgConfig = new OrganizationMaintainConfig(OrgRoleType.ORG).withAlias();
 		MaintainOrgBuilder org = fhirController.createOrganization(orgConfig);
 		MaintainOrgBuilder orgQueried = fhirController.queryOrganizationByIdentifier(IdentifierType.IPC,
@@ -211,7 +219,6 @@ public class SearchProviderTests implements SimpleTest {
 		PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
 		SearchProviderPage searchProviderPage = workflow.getPlrWebAccessActions().openSearchProvider();
 		// FHIR
-		FHIRController fhirController = new FHIRController(UserType.ADMIN);
 		IndividualBuilderFactory individualFactory = new IndividualBuilderFactory(
 				IndividualDataGenerator.getInstance());
 
@@ -236,7 +243,6 @@ public class SearchProviderTests implements SimpleTest {
 		PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
 		SearchProviderPage searchProvider = workflow.getPlrWebAccessActions().openSearchProvider();
 		// FHIR
-		FHIRController fhirController = new FHIRController(UserType.ADMIN);
 		IndividualBuilderFactory individualFactory = new IndividualBuilderFactory(
 				IndividualDataGenerator.getInstance());
 		int roandomNumber=getRandomNumber(3,5);
@@ -299,7 +305,6 @@ public class SearchProviderTests implements SimpleTest {
 		PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
 		SearchProviderPage searchProviderPage = workflow.getPlrWebAccessActions().openSearchProvider();
 		// FHIR
-		FHIRController fhirController = new FHIRController(UserType.ADMIN);
 		IndividualBuilderFactory individualFactory = new IndividualBuilderFactory(
 				IndividualDataGenerator.getInstance());
 
@@ -364,7 +369,6 @@ public class SearchProviderTests implements SimpleTest {
 		PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
 		SearchProviderPage searchProviderPage = workflow.getPlrWebAccessActions().openSearchProvider();
 		// FHIR
-		FHIRController fhirController = new FHIRController(UserType.ADMIN);
 		IndividualBuilderFactory individualFactory = new IndividualBuilderFactory(
 				IndividualDataGenerator.getInstance());
 
@@ -412,7 +416,6 @@ public class SearchProviderTests implements SimpleTest {
 		PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
 		SearchProviderPage searchProviderPage = workflow.getPlrWebAccessActions().openSearchProvider();
 		// FHIR
-		FHIRController fhirController = new FHIRController(UserType.ADMIN);
 		OrganizationMaintainConfig orgConfig = new OrganizationMaintainConfig(OrgRoleType.ORG).withAlias();
 		MaintainOrgBuilder org = fhirController.createOrganization(orgConfig);
 		MaintainOrgBuilder orgQueried = fhirController.queryOrganizationByIdentifier(IdentifierType.IPC,
@@ -454,7 +457,6 @@ public class SearchProviderTests implements SimpleTest {
 		PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
 		SearchProviderPage searchProviderPage = workflow.getPlrWebAccessActions().openSearchProvider();
 		// FHIR
-		FHIRController fhirController = new FHIRController(UserType.ADMIN);
 		IndividualBuilderFactory individualFactory = new IndividualBuilderFactory(
 				IndividualDataGenerator.getInstance());
 
@@ -516,7 +518,6 @@ public class SearchProviderTests implements SimpleTest {
 	@Test(groups = { "SearchProvider" })
 	public void testSearchHDS() {
 		PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
-		FHIRController fhirController = new FHIRController(UserType.ADMIN);
 		OrganizationMaintainConfig orgConfig = new OrganizationMaintainConfig(OrgRoleType.HDS).withAlias();
 		MaintainOrgBuilder org = fhirController.createOrganization(orgConfig);
 		MaintainOrgBuilder orgQueried = fhirController.queryOrganizationByIdentifier(IdentifierType.IPC,
@@ -552,22 +553,35 @@ public class SearchProviderTests implements SimpleTest {
 		assertTrue(searchResults.grabResultsRowCount() > 0, "search result has too less rows");
 
 	}
-	
-	/**
-	 * get Random Number
-	 * @param min	the min number
-	 * @param max 	the max number
-	 * @return 		random number between min and max
-	 */
-	private int getRandomNumber(int min, int max) {
-		// Create a Random object
-		Random random = new Random();
 
-		// Generate the random number
-		// nextInt((max - min) + 1) generates a number between 0 and 4
-		// Adding min (2) shifts the range to be between 2 and 6 (exclusive of 6)
-		return random.nextInt((max - min) + 1) + min;
+	// Confidential Record Attribute Search
+	@Test(groups = { "SearchProvider" })
+	public void testConfidentialRecordAttributeSearch()
+	{
+		final PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
 
+		// FHIR Prep (if needed)
+		List<MaintainOrgBuilder> query = fhirController.queryOrganizationByCriteria(
+				new OrgQueryCriteriaParams().setName("ConfidentialRecord"));
+
+		if (query.isEmpty())
+		{
+			MaintainOrgBuilder org = fhirController.createOrganization(
+					new OrganizationMaintainConfig(OrgRoleType.ORG).withName("ConfidentialRecord").withConfidentiality());
+		}
+
+		SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
+
+		// Search by Criteria
+		provider.searchByCriteria(OrgRoleType.ORG.name(), "ConfidentialRecord",
+				null, null, null, null, null);
+		assertEquals(warningList.get("confidentialRecordFound"), provider.grabWarningErrorMessage(),
+				"Expected warning message not found");
+
+		// Search by Organization
+		provider.searchForOrganization(OrgRoleType.ORG.name(), "ConfidentialRecord",
+				null, null, null);
+		assertEquals(warningList.get("confidentialRecordFound"), provider.grabWarningErrorMessage(),
+				"Expected warning message not found");
 	}
-
 }

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
@@ -83,7 +83,7 @@ public class SearchProviderTests implements SimpleTest {
 	@AfterClass
 	private void teardown() {
 		fhirController.close();
-		workflowManager_.logoutAllAndClose();
+		//workflowManager_.logoutAllAndClose();
 		LOG.info("Done.");
 	}
 
@@ -330,20 +330,7 @@ public class SearchProviderTests implements SimpleTest {
 		}
 
 		// Test Start
-		SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
-
-		String identifier;
-		if (isOrganization) identifier = confOrg.getIdentifier(IdentifierType.IPC);
-		else identifier = confInd.getIdentifier(IdentifierType.IPC);
-
-		SearchProviderResultsFragment results = provider.searchByIdentifier("IPC", identifier);
-		List<String> resultInfo = results.grabResultsRow(0);
-		assertEquals(resultInfo.getFirst(), "Link to View Provider", "Record name not confidentially masked");
-
-		ViewProviderPage page = actions.openSearchResults(0);
-
-		assertEquals(page.getViewHeader().grabViewTitle().split(" ")[0], "Confidential",
-				"Record name in title not confidentially masked");
+		ViewProviderPage page = actions.openConfidentialRecord(workflow, isOrganization, confOrg, confInd);
 
 		// Verify confidential sections are masked
 		for (ProviderSection section : ProviderSection.getProviderSectionSet(providerType))
@@ -847,11 +834,8 @@ public class SearchProviderTests implements SimpleTest {
 		page = viewByIdentifierAsUpdateOrg(org.getIdentifier(IdentifierType.IPC), workflowManager_);
 		page.updateIdentifierDataBlock(orgID, EndReason.CORR, 2, false);
 		page.updateRegistryIdentifierDataBlock(StringUtils.getDigits(regID), EndReason.CORR, 0, false);
-		//ind.familyName("TestIndIncorrectData");
-		//fhirController.submitIndividual(ind);
-		indPage = viewByIdentifierAsUpdateIndividual(ind.getIdentifier(IdentifierType.IPC), workflowManager_);
-		indPage.updatePractitionerNameDataBlock("", "Test", "", "",
-				"TestIndIncorrectData", "", EndReason.CORR, 0, false);
+		ind.familyName("TestIndIncorrectData");
+		fhirController.submitIndividual(ind);
 	}
 
 	// Viewing Permissions for Confidential Provider Records
@@ -880,21 +864,7 @@ public class SearchProviderTests implements SimpleTest {
 			if (!workflow.isLoggedIn()) { workflow.login().openPlr(); }
 			final SearchProviderActions actions = workflowManager_.getSelectedWorkflow().getSearchProviderActions();
 
-			SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
-
-			String identifier;
-			if (isOrganization) identifier = confOrg.getIdentifier(IdentifierType.IPC);
-			else identifier = confInd.getIdentifier(IdentifierType.IPC);
-
-			SearchProviderResultsFragment results = provider.searchByIdentifier("IPC", identifier);
-			List<String> resultInfo = results.grabResultsRow(0);
-			assertNotEquals(resultInfo.getFirst(), "Link to View Provider",
-					"Record name confidentially masked unexpectedly");
-
-			ViewProviderPage page = actions.openSearchResults(0);
-
-			assertNotEquals(page.getViewHeader().grabViewTitle().split(" ")[0], "Confidential",
-					"Record name in title confidentially masked unexpectedly");
+			ViewProviderPage page = actions.openConfidentialRecord(workflow, isOrganization, confOrg, confInd);
 
 			for (ProviderSection section : ProviderSection.getProviderSectionSet(providerType))
 			{

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
@@ -51,6 +51,10 @@ import ca.bc.gov.health.qa.autotest.runner.util.testng.SimpleTest;
 
 /** Tests class for the Search Provider page */
 public class SearchProviderTests implements SimpleTest {
+	// NOTE: The following test cases *WILL NOT* be automated:
+	// - Search Provider : Configurable The Number of Search Results
+	// - Search Provider : Limiting The Number of Search Records Returned By The DB
+
 	private static final Logger LOG = ExecutionLogManager.getLogger();
 
 	private final PlrWebWorkflowManager workflowManager_ = new PlrWebWorkflowManager();
@@ -78,6 +82,7 @@ public class SearchProviderTests implements SimpleTest {
 
 	@AfterClass
 	private void teardown() {
+		fhirController.close();
 		workflowManager_.logoutAllAndClose();
 		LOG.info("Done.");
 	}
@@ -431,6 +436,76 @@ public class SearchProviderTests implements SimpleTest {
 
 		// Search by Criteria / Search by Organization
 		testConfidentialRecordAttributeSearch();
+	}
+
+	// Search - HDS Organization Provider
+	@Test(groups = { "SearchProvider" })
+	public void testHDSOrganizationProvider() {
+		final PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
+
+		/* This test case cannot ensure there is an HDS organization of type CLINIC existing in the system.
+		 * It will create one if an HDS type organization with the other parameters does not exist -
+		 * but if one already exists, it cannot guarantee it is of type CLINIC (which is used for testing HDS Type) */
+		List<MaintainOrgBuilder> hdsQuery = fhirController.queryOrganizationByCriteria(
+				new OrgQueryCriteriaParams().setRoleType(OrgRoleType.HDS)
+						.setName("HDSOrgTest")
+						.setDescription("HDSOrgDesc")
+						.setAddressLine1("1175 DOUGLAS ST")
+						.setAddressCity("Victoria"));
+
+		if (hdsQuery == null)
+		{
+			final OrganizationDataGenerator dataGen = OrganizationDataGenerator.getInstance();
+			OrganizationMaintainConfig orgConfig = new OrganizationMaintainConfig(OrgRoleType.HDS).withName("HDSOrgTest");
+			MaintainOrgBuilder builder = new OrganizationBuilderFactory(dataGen).build(orgConfig)
+					.hdsType(HdsType.CLINIC)
+					.alias("HDSOrgDesc")
+					.setAddressList(List.of())
+					.addAddress("physical", "BC", "1175 DOUGLAS ST", "Victoria", "V8W 2E1");
+			fhirController.submitOrganization(builder);
+		}
+
+		// Test Start
+		SearchProviderPage providerPage = workflow.getPlrWebAccessActions().openSearchProvider();
+		SearchProviderResultsFragment results = providerPage.searchHDSOrganization(
+				HdsType.CLINIC.name(),
+				"HDSOrgTest",
+				"HDSOrgDesc",
+				"Victoria",
+				"1175 DOUGLAS ST");
+		assertTrue(results.grabResultsRowCount() > 0, "Search results returned nothing unexpectedly");
+		assertEquals(providerPage.grabPageErrorMessage(), "", "Unexpected error message found");
+
+		// Role Type + HDS Type only
+		results = providerPage.searchHDSOrganization(HdsType.CLINIC.name(),
+				"", "", "", "");
+		assertEquals(results.grabResultsRowCount(), 0, "Search results returned records unexpectedly");
+		assertEquals(providerPage.grabPageErrorMessage(), errorList.get("errorEntryError"),
+				"Expected error message not found");
+
+		// City + Address Line 1 blank
+		results = providerPage.searchHDSOrganization(HdsType.CLINIC.name(), "HDSOrgTest", "HDSOrgDesc",
+				"", "");
+		assertTrue(results.grabResultsRowCount() > 0, "Search results returned nothing unexpectedly");
+		assertEquals(providerPage.grabPageErrorMessage(), "", "Unexpected error message found");
+
+		// City only
+		results = providerPage.searchHDSOrganization(HdsType.CLINIC.name(), "", "",
+				"Victoria", "");
+		assertTrue(results.grabResultsRowCount() > 0, "Search results returned nothing unexpectedly");
+		assertEquals(providerPage.grabPageErrorMessage(), "", "Unexpected error message found");
+
+		// Description only
+		results = providerPage.searchHDSOrganization(HdsType.CLINIC.name(), "", "HDSOrgDesc",
+				"", "");
+		assertTrue(results.grabResultsRowCount() > 0, "Search results returned nothing unexpectedly");
+		assertEquals(providerPage.grabPageErrorMessage(), "", "Unexpected error message found");
+
+		// Address Line 1 only
+		results = providerPage.searchHDSOrganization(HdsType.CLINIC.name(), "", "",
+				"", "1175 DOUGLAS ST");
+		assertTrue(results.grabResultsRowCount() > 0, "Search results returned nothing unexpectedly");
+		assertEquals(providerPage.grabPageErrorMessage(), "", "Unexpected error message found");
 	}
 
 	// Search - Individual Provider

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
@@ -1,8 +1,7 @@
 package ca.bc.gov.health.qa.autotest.plr.web.tests.provider;
 
 import static ca.bc.gov.health.qa.autotest.plr.web.tests.TestHelper.getRandomNumber;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -10,6 +9,7 @@ import java.nio.file.Path;
 import java.util.*;
 
 import ca.bc.gov.health.qa.autotest.plr.data.InjectableData;
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.MaintainRequestBuilder;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.query.IndividualQueryCriteriaParams;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.query.OrgQueryCriteriaParams;
 import ca.bc.gov.health.qa.autotest.plr.util.ProviderType;
@@ -554,25 +554,31 @@ public class SearchProviderTests implements SimpleTest {
 	}
 
 	// Confidential Mask
-	@Test(groups = { "SearchProvider" }, dataProvider = "indOrgTypes", dataProviderClass = InjectableData.class)
-	public void testConfidentialMask(ProviderType providerType)
+	@Test(groups = { "SearchProvider" }, dataProvider = "indOrgBuilderTypes", dataProviderClass = InjectableData.class)
+	public void testConfidentialMask(ProviderType providerType, MaintainRequestBuilder confidentialRecord)
 	{
 		final PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.SECONDARY);
 		if (!workflow.isLoggedIn()) { workflow.login().openPlr(); }
 		final SearchProviderActions actions = workflowManager_.getSelectedWorkflow().getSearchProviderActions();
 
-		// FHIR Prep
+		// FHIR Prep - if confidentialRecord is set use that record instead of creating anything new
+		boolean isOrganization;
 		MaintainIndividualBuilder confInd = null;
 		MaintainOrgBuilder confOrg = null;
-		switch (providerType)
-		{
-			case BC_PRACTITIONER -> confInd = fhirController.createIndividual(
-					new IndividualMaintainConfig(IndividualRoleType.MD).withConfidentiality());
-            case ORGANIZATION -> confOrg = fhirController.createOrganization(
-					new OrganizationMaintainConfig(OrgRoleType.ORG).withConfidentiality());
-			default -> throw new IllegalStateException("Unsupported provider type " + providerType.name());
-        }
-		boolean isOrganization = !Objects.isNull(confOrg);
+		if (confidentialRecord == null) {
+			switch (providerType) {
+				case BC_PRACTITIONER -> confInd = fhirController.createIndividual(
+						new IndividualMaintainConfig(IndividualRoleType.MD).withConfidentiality());
+				case ORGANIZATION -> confOrg = fhirController.createOrganization(
+						new OrganizationMaintainConfig(OrgRoleType.ORG).withConfidentiality());
+				default -> throw new IllegalStateException("Unsupported provider type " + providerType.name());
+			}
+			isOrganization = !Objects.isNull(confOrg);
+		} else {
+			isOrganization = confidentialRecord instanceof MaintainOrgBuilder;
+			if (isOrganization) confOrg = (MaintainOrgBuilder) confidentialRecord;
+			else confInd = (MaintainIndividualBuilder) confidentialRecord;
+		}
 
 		// Test Start
 		SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
@@ -681,5 +687,60 @@ public class SearchProviderTests implements SimpleTest {
 
 		// Search by Criteria / Search by Organization
 		testConfidentialRecordAttributeSearch();
+	}
+
+	// Viewing Permissions for Confidential Provider Records
+	@Test(groups = { "SearchProvider" }, dataProvider = "indOrgTypes", dataProviderClass = InjectableData.class)
+	public void testViewPermissionsConfidentialRecords(ProviderType providerType)
+	{
+		// FHIR Prep
+		final FHIRController primaryController = new FHIRController(UserType.PRIMARY);
+		MaintainIndividualBuilder confInd = null;
+		MaintainOrgBuilder confOrg = null;
+		switch (providerType)
+		{
+			case BC_PRACTITIONER -> confInd = primaryController.createIndividual(
+					new IndividualMaintainConfig(IndividualRoleType.MD).withConfidentiality());
+			case ORGANIZATION -> confOrg = primaryController.createOrganization(
+					new OrganizationMaintainConfig(OrgRoleType.ORG).withConfidentiality());
+			default -> throw new IllegalStateException("Unsupported provider type " + providerType.name());
+		}
+		boolean isOrganization = !Objects.isNull(confOrg);
+
+		// Test Start (checking Reg-Admin access to anything and Primary access to its own confidential record)
+		for (UserType userType : List.of(UserType.ADMIN, UserType.PRIMARY))
+		{
+			final PlrWebWorkflow workflow = workflowManager_.selectWorkflow(userType);
+			if (!workflow.isLoggedIn()) { workflow.login().openPlr(); }
+			final SearchProviderActions actions = workflowManager_.getSelectedWorkflow().getSearchProviderActions();
+
+			SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
+
+			String identifier;
+			if (isOrganization) identifier = confOrg.getIdentifier(IdentifierType.IPC);
+			else identifier = confInd.getIdentifier(IdentifierType.IPC);
+
+			SearchProviderResultsFragment results = provider.searchByIdentifier("IPC", identifier);
+			List<String> resultInfo = results.grabResultsRow(0);
+			assertNotEquals(resultInfo.getFirst(), "Link to View Provider",
+					"Record name confidentially masked unexpectedly");
+
+			ViewProviderPage page = actions.openSearchResults(0);
+
+			assertNotEquals(page.getViewHeader().grabViewTitle().split(" ")[0], "Confidential",
+					"Record name in title confidentially masked unexpectedly");
+
+			for (ProviderSection section : ProviderSection.getProviderSectionSet(providerType))
+			{
+				if (!section.isRequired()) continue;
+				if (userType.equals(UserType.PRIMARY) && section.equals(ProviderSection.REGISTRY_IDENTIFIERS)) continue;
+
+				assertTrue(page.grabDataBlockCount(section) > 0,
+						"Expected record data not found in section: " + section.name());
+			}
+		}
+
+		// checking secondary
+		testConfidentialMask(providerType, isOrganization ? confOrg : confInd);
 	}
 }

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
@@ -1,6 +1,6 @@
 package ca.bc.gov.health.qa.autotest.plr.web.tests.provider;
 
-import static ca.bc.gov.health.qa.autotest.plr.web.tests.TestHelper.getRandomNumber;
+import static ca.bc.gov.health.qa.autotest.plr.web.tests.TestHelper.*;
 import static org.testng.Assert.*;
 
 import java.io.IOException;
@@ -14,8 +14,9 @@ import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.query.Individua
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.query.OrgQueryCriteriaParams;
 import ca.bc.gov.health.qa.autotest.plr.util.ProviderType;
 import ca.bc.gov.health.qa.autotest.plr.web.actions.provider.SearchProviderActions;
-import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.ProviderSection;
-import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.ViewProviderPage;
+import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.*;
+import ca.bc.gov.health.qa.autotest.plr.web.tests.model.EndReason;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 import org.testng.annotations.AfterClass;
@@ -41,8 +42,6 @@ import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.MaintainOrgBu
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.model.HdsType;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.model.OrgRoleType;
 import ca.bc.gov.health.qa.autotest.plr.util.UserType;
-import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.SearchProviderPage;
-import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.SearchProviderResultsFragment;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.helper.UpdateSimpleHelper;
 import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflow;
 import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflowManager;
@@ -84,7 +83,7 @@ public class SearchProviderTests implements SimpleTest {
 	@AfterClass
 	private void teardown() {
 		fhirController.close();
-		//workflowManager_.logoutAllAndClose();
+		workflowManager_.logoutAllAndClose();
 		LOG.info("Done.");
 	}
 
@@ -759,6 +758,102 @@ public class SearchProviderTests implements SimpleTest {
 				"Permission info message not found");
 	}
 
+	// Searching Incorrect Data
+	@Test(groups = { "SearchProvider" })
+	public void testSearchingIncorrectData() {
+		final PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
+
+		UpdateOrganizationPage page;
+		SearchProviderPage provider;
+		SearchProviderResultsFragment results;
+
+		// FHIR Prep
+		MaintainOrgBuilder org;
+		List<MaintainOrgBuilder> orgQuery = fhirController.queryOrganizationByCriteria(
+				new OrgQueryCriteriaParams().setName("TestOrgIncorrectData"));
+		if (orgQuery.isEmpty()) {
+			MaintainOrgBuilder builder = new OrganizationBuilderFactory(OrganizationDataGenerator.getInstance())
+					.build(new OrganizationMaintainConfig(OrgRoleType.ORG).withName("TestOrgIncorrectData"))
+					.addIdentifier(IdentifierType.ORGID, UpdateSimpleHelper.generateNumericString(16));
+			String identifier = fhirController.submitOrganization(builder).getIdentifier(IdentifierType.IPC);
+			org = fhirController.queryOrganizationByIdentifier(IdentifierType.IPC, identifier);
+		} else org = orgQuery.getFirst();
+
+		MaintainIndividualBuilder ind;
+		List<MaintainIndividualBuilder> indQuery = fhirController.queryIndividualByCriteria(
+				new IndividualQueryCriteriaParams().setFamily("TestIndIncorrectData").setAddressCity("Victoria"));
+		if (indQuery.isEmpty()) {
+			MaintainIndividualBuilder builder = new IndividualBuilderFactory(IndividualDataGenerator.getInstance())
+					.build(new IndividualMaintainConfig(IndividualRoleType.MD)).familyName("TestIndIncorrectData")
+					.setAddressList(List.of(Map.of(
+							"type", "physical",
+							"purpose", "BC",
+							"line1", "1175 DOUGLAS ST",
+							"city", "Victoria",
+							"postalCode", "V8W 2E1")));
+			builder = fhirController.submitIndividual(builder);
+			LOG.info("here we have");
+			LOG.info(builder);
+			LOG.info(builder.getIdentifiers());
+			String identifier = builder.getIdentifier(IdentifierType.IPC);
+			LOG.info(identifier);
+			LOG.info("^^^ should not be null");
+			ind = fhirController.queryIndividualByIdentifier(IdentifierType.IPC, identifier);
+		} else ind = indQuery.getFirst();
+
+		// Criteria Name Correction
+		UpdateProviderPage indPage = viewByIdentifierAsUpdateIndividual(ind.getIdentifier(IdentifierType.IPC), workflowManager_);
+		indPage.updatePractitionerNameDataBlock("", "Test", "", "",
+				"InactiveNewName", "", EndReason.CORR, 0, false);
+		provider = workflow.getPlrWebAccessActions().openSearchProvider();
+		results = provider.searchByCriteria(IndividualRoleType.MD.name(), null, "TestIndIncorrectData",
+				null, "Victoria", null, null);
+		assertEquals(results.grabResultsRowCount(), 0,
+				"Search results returned a record for incorrect name unexpectedly");
+
+		// Identifier Correction
+		final String orgID = org.getIdentifier(IdentifierType.ORGID);
+		page = viewByIdentifierAsUpdateOrg(org.getIdentifier(IdentifierType.IPC), workflowManager_);
+		// assumes the identifier order is CPN, IPC, ORGID - adjust if method of adding identifiers through FHIR changes this
+		page.updateIdentifierDataBlock("9999999999999999", EndReason.CORR, 2, false);
+		provider = workflow.getPlrWebAccessActions().openSearchProvider();
+		results = provider.searchByIdentifier(IdentifierType.ORGID.name(), orgID);
+		assertEquals(results.grabResultsRowCount(), 0,
+				"Search results returned a record for incorrect identifier unexpectedly");
+
+		// Registry Identifier Correction
+		final String regID = org.getIdentifier(IdentifierType.CPN);
+		page = viewByIdentifierAsUpdateOrg(org.getIdentifier(IdentifierType.IPC), workflowManager_);
+		// assumes the identifier order is CPN, IPC - adjust if method of adding identifiers through FHIR changes this
+		page.updateRegistryIdentifierDataBlock("99999999", EndReason.CORR, 0, false);
+		provider = workflow.getPlrWebAccessActions().openSearchProvider();
+		results = provider.searchByRegistryIdentifier(
+				IdentifierType.CPN.name(), StringUtils.getDigits(regID));
+		assertEquals(results.grabResultsRowCount(), 0,
+				"Search results returned a record for incorrect registry identifier unexpectedly");
+
+		// Organization Name Correction
+		page = viewByIdentifierAsUpdateOrg(org.getIdentifier(IdentifierType.IPC), workflowManager_);
+		page.updateOrganizationNameDataBlock("InactiveNewName", "", EndReason.CORR, 0, false);
+		provider = workflow.getPlrWebAccessActions().openSearchProvider();
+		results = provider.searchForOrganization(
+				OrgRoleType.ORG.name(), "TestOrgIncorrectData", null, null, null);
+		assertEquals(results.grabResultsRowCount(), 0,
+				"Search results returned a record for incorrect name unexpectedly");
+
+		// Cleanup
+		org.name("TestOrgIncorrectData");
+		fhirController.submitOrganization(org);
+		page = viewByIdentifierAsUpdateOrg(org.getIdentifier(IdentifierType.IPC), workflowManager_);
+		page.updateIdentifierDataBlock(orgID, EndReason.CORR, 2, false);
+		page.updateRegistryIdentifierDataBlock(StringUtils.getDigits(regID), EndReason.CORR, 0, false);
+		//ind.familyName("TestIndIncorrectData");
+		//fhirController.submitIndividual(ind);
+		indPage = viewByIdentifierAsUpdateIndividual(ind.getIdentifier(IdentifierType.IPC), workflowManager_);
+		indPage.updatePractitionerNameDataBlock("", "Test", "", "",
+				"TestIndIncorrectData", "", EndReason.CORR, 0, false);
+	}
+
 	// Viewing Permissions for Confidential Provider Records
 	@Test(groups = { "SearchProvider" }, dataProvider = "indOrgTypes", dataProviderClass = InjectableData.class)
 	public void testViewPermissionsConfidentialRecords(ProviderType providerType)
@@ -775,6 +870,7 @@ public class SearchProviderTests implements SimpleTest {
 					new OrganizationMaintainConfig(OrgRoleType.ORG).withConfidentiality());
 			default -> throw new IllegalStateException("Unsupported provider type " + providerType.name());
 		}
+		primaryController.close();
 		boolean isOrganization = !Objects.isNull(confOrg);
 
 		// Test Start (checking Reg-Admin access to anything and Primary access to its own confidential record)

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.query.IndividualQueryCriteriaParams;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.query.OrgQueryCriteriaParams;
 import ca.bc.gov.health.qa.autotest.plr.web.actions.provider.SearchProviderActions;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.common.AlertMessagesFragment;
@@ -559,28 +560,41 @@ public class SearchProviderTests implements SimpleTest {
 	public void testConfidentialRecordAttributeSearch()
 	{
 		final PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
+		final IndividualDataGenerator dataGen = IndividualDataGenerator.getInstance();
 
 		// FHIR Prep (if needed)
-		List<MaintainOrgBuilder> query = fhirController.queryOrganizationByCriteria(
+		List<MaintainOrgBuilder> orgQuery = fhirController.queryOrganizationByCriteria(
 				new OrgQueryCriteriaParams().setName("ConfidentialRecord"));
 
-		if (query.isEmpty())
+		if (orgQuery.isEmpty())
 		{
-			MaintainOrgBuilder org = fhirController.createOrganization(
-					new OrganizationMaintainConfig(OrgRoleType.ORG).withName("ConfidentialRecord").withConfidentiality());
+			fhirController.createOrganization(new OrganizationMaintainConfig(OrgRoleType.ORG)
+					.withName("ConfidentialRecord").withConfidentiality());
+		}
+
+		List<MaintainIndividualBuilder> indQuery = fhirController.queryIndividualByCriteria(
+				new IndividualQueryCriteriaParams().setFamily("ConfidentialRecord").setExpertise("ENG"));
+
+		if (indQuery.isEmpty())
+		{
+			MaintainIndividualBuilder ind = new IndividualBuilderFactory(dataGen)
+					.build(new IndividualMaintainConfig(IndividualRoleType.MD).withConfidentiality())
+					.familyName("ConfidentialRecord").addExpertise("ENG", dataGen.shortText());
+			fhirController.submitIndividual(ind);
 		}
 
 		SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
 
 		// Search by Criteria
-		provider.searchByCriteria(OrgRoleType.ORG.name(), "ConfidentialRecord",
-				null, null, null, null, null);
+		provider.searchByCriteria(IndividualRoleType.MD.name(), null, "ConfidentialRecord",
+				null, null, null, null,
+				null, List.of("ENG"));
 		assertEquals(warningList.get("confidentialRecordFound"), provider.grabWarningErrorMessage(),
 				"Expected warning message not found");
 
 		// Search by Organization
-		provider.searchForOrganization(OrgRoleType.ORG.name(), "ConfidentialRecord",
-				null, null, null);
+		provider.searchForOrganization(null, "ConfidentialRecord", null,
+				null, null);
 		assertEquals(warningList.get("confidentialRecordFound"), provider.grabWarningErrorMessage(),
 				"Expected warning message not found");
 	}

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
@@ -297,6 +297,142 @@ public class SearchProviderTests implements SimpleTest {
 
 	}
 
+	// Search - Confidential Mask
+	@Test(groups = { "SearchProvider" }, dataProvider = "indOrgBuilderTypes", dataProviderClass = InjectableData.class)
+	public void testConfidentialMask(ProviderType providerType, MaintainRequestBuilder confidentialRecord)
+	{
+		final PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.SECONDARY);
+		if (!workflow.isLoggedIn()) { workflow.login().openPlr(); }
+		final SearchProviderActions actions = workflowManager_.getSelectedWorkflow().getSearchProviderActions();
+
+		// FHIR Prep - if confidentialRecord is set use that record instead of creating anything new
+		boolean isOrganization;
+		MaintainIndividualBuilder confInd = null;
+		MaintainOrgBuilder confOrg = null;
+		if (confidentialRecord == null) {
+			switch (providerType) {
+				case BC_PRACTITIONER -> confInd = fhirController.createIndividual(
+						new IndividualMaintainConfig(IndividualRoleType.MD).withConfidentiality());
+				case ORGANIZATION -> confOrg = fhirController.createOrganization(
+						new OrganizationMaintainConfig(OrgRoleType.ORG).withConfidentiality());
+				default -> throw new IllegalStateException("Unsupported provider type " + providerType.name());
+			}
+			isOrganization = !Objects.isNull(confOrg);
+		} else {
+			isOrganization = confidentialRecord instanceof MaintainOrgBuilder;
+			if (isOrganization) confOrg = (MaintainOrgBuilder) confidentialRecord;
+			else confInd = (MaintainIndividualBuilder) confidentialRecord;
+		}
+
+		// Test Start
+		SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
+
+		String identifier;
+		if (isOrganization) identifier = confOrg.getIdentifier(IdentifierType.IPC);
+		else identifier = confInd.getIdentifier(IdentifierType.IPC);
+
+		SearchProviderResultsFragment results = provider.searchByIdentifier("IPC", identifier);
+		List<String> resultInfo = results.grabResultsRow(0);
+		assertEquals(resultInfo.getFirst(), "Link to View Provider", "Record name not confidentially masked");
+
+		ViewProviderPage page = actions.openSearchResults(0);
+
+		assertEquals(page.getViewHeader().grabViewTitle().split(" ")[0], "Confidential",
+				"Record name in title not confidentially masked");
+
+		// Verify confidential sections are masked
+		for (ProviderSection section : ProviderSection.getProviderSectionSet(providerType))
+		{
+			switch (section)
+			{
+				case IDENTIFIERS, ROLE_TYPE:
+					continue;
+				case PRACTITIONER_NAMES, ORGANIZATION_NAMES:
+					String nameField = section.equals(ProviderSection.ORGANIZATION_NAMES) ? "Name" : "Surname";
+					String name = page.grabDataBlockContent(section, 0).get(nameField);
+					assertEquals(name, "Confidential", "Surname not set as confidential");
+					continue;
+			}
+			assertEquals(page.grabDataBlockCount(section), 0,
+					"Confidential record data found in section: " + section.name());
+		}
+	}
+
+	// Search - Confidential Record Attribute Search
+	@Test(groups = { "SearchProvider" })
+	public void testConfidentialRecordAttributeSearch()
+	{
+		final PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
+		final IndividualDataGenerator dataGen = IndividualDataGenerator.getInstance();
+
+		// FHIR Prep (if needed)
+		List<MaintainOrgBuilder> orgQuery = fhirController.queryOrganizationByCriteria(
+				new OrgQueryCriteriaParams().setName("ConfidentialRecord"));
+
+		if (orgQuery.isEmpty())
+		{
+			fhirController.createOrganization(new OrganizationMaintainConfig(OrgRoleType.ORG)
+					.withName("ConfidentialRecord").withConfidentiality());
+		}
+
+		List<MaintainIndividualBuilder> indQuery = fhirController.queryIndividualByCriteria(
+				new IndividualQueryCriteriaParams().setFamily("ConfidentialRecord").setExpertise("ENG"));
+
+		if (indQuery.isEmpty())
+		{
+			MaintainIndividualBuilder ind = new IndividualBuilderFactory(dataGen)
+					.build(new IndividualMaintainConfig(IndividualRoleType.MD).withConfidentiality())
+					.familyName("ConfidentialRecord").addExpertise("ENG", dataGen.shortText());
+			fhirController.submitIndividual(ind);
+		}
+
+		SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
+
+		// Search by Criteria
+		provider.searchByCriteria(IndividualRoleType.MD.name(), null, "ConfidentialRecord",
+				null, null, null, null,
+				null, List.of("ENG"));
+		assertEquals(warningList.get("confidentialRecordFound"), provider.grabWarningErrorMessage(),
+				"Expected warning message not found");
+
+		// Search by Organization
+		provider.searchForOrganization(null, "ConfidentialRecord", null,
+				null, null);
+		assertEquals(warningList.get("confidentialRecordFound"), provider.grabWarningErrorMessage(),
+				"Expected warning message not found");
+	}
+
+	// Search - Confidential Record ID Search
+	@Test(groups = { "SearchProvider" })
+	public void testConfidentialRecordIDSearch()
+	{
+		final PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
+
+		// FHIR Prep
+		MaintainIndividualBuilder confidentialInd = fhirController.createIndividual(
+				new IndividualMaintainConfig(IndividualRoleType.MD).withConfidentiality());
+
+		SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
+
+		// Search by Identifier
+		SearchProviderResultsFragment results = provider.searchByIdentifier("IPC",
+				confidentialInd.getIdentifier(IdentifierType.IPC));
+		List<String> resultInfo = results.grabResultsRow(0);
+		assertTrue(Objects.nonNull(resultInfo),
+				"Search by Identifier for confidential record was unsuccessful");
+
+		// Search by Registry Identifier
+		String ipcID = UpdateSimpleHelper.getRegIdString(IdentifierType.IPC.name(),
+				confidentialInd.getIdentifier(IdentifierType.IPC));
+		results = provider.searchByRegistryIdentifier("IPC", ipcID);
+		resultInfo = results.grabResultsRow(0);
+		assertTrue(Objects.nonNull(resultInfo),
+				"Search by Registry Identifier for confidential record was unsuccessful");
+
+		// Search by Criteria / Search by Organization
+		testConfidentialRecordAttributeSearch();
+	}
+
 	// Search - Individual Provider
 	@Test(groups = { "SearchProvider" })
 	public void testSearchIndividualProvider() {
@@ -551,142 +687,6 @@ public class SearchProviderTests implements SimpleTest {
 		searchResults = searchProviderPage.searchHDSOrganization(hdsType.name(), null, null, null, addressline1);
 		assertTrue(searchResults.grabResultsRowCount() > 0, "search result has too less rows");
 
-	}
-
-	// Confidential Mask
-	@Test(groups = { "SearchProvider" }, dataProvider = "indOrgBuilderTypes", dataProviderClass = InjectableData.class)
-	public void testConfidentialMask(ProviderType providerType, MaintainRequestBuilder confidentialRecord)
-	{
-		final PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.SECONDARY);
-		if (!workflow.isLoggedIn()) { workflow.login().openPlr(); }
-		final SearchProviderActions actions = workflowManager_.getSelectedWorkflow().getSearchProviderActions();
-
-		// FHIR Prep - if confidentialRecord is set use that record instead of creating anything new
-		boolean isOrganization;
-		MaintainIndividualBuilder confInd = null;
-		MaintainOrgBuilder confOrg = null;
-		if (confidentialRecord == null) {
-			switch (providerType) {
-				case BC_PRACTITIONER -> confInd = fhirController.createIndividual(
-						new IndividualMaintainConfig(IndividualRoleType.MD).withConfidentiality());
-				case ORGANIZATION -> confOrg = fhirController.createOrganization(
-						new OrganizationMaintainConfig(OrgRoleType.ORG).withConfidentiality());
-				default -> throw new IllegalStateException("Unsupported provider type " + providerType.name());
-			}
-			isOrganization = !Objects.isNull(confOrg);
-		} else {
-			isOrganization = confidentialRecord instanceof MaintainOrgBuilder;
-			if (isOrganization) confOrg = (MaintainOrgBuilder) confidentialRecord;
-			else confInd = (MaintainIndividualBuilder) confidentialRecord;
-		}
-
-		// Test Start
-		SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
-
-		String identifier;
-		if (isOrganization) identifier = confOrg.getIdentifier(IdentifierType.IPC);
-		else identifier = confInd.getIdentifier(IdentifierType.IPC);
-
-		SearchProviderResultsFragment results = provider.searchByIdentifier("IPC", identifier);
-		List<String> resultInfo = results.grabResultsRow(0);
-		assertEquals(resultInfo.getFirst(), "Link to View Provider", "Record name not confidentially masked");
-
-		ViewProviderPage page = actions.openSearchResults(0);
-
-		assertEquals(page.getViewHeader().grabViewTitle().split(" ")[0], "Confidential",
-				"Record name in title not confidentially masked");
-
-		// Verify confidential sections are masked
-		for (ProviderSection section : ProviderSection.getProviderSectionSet(providerType))
-		{
-			switch (section)
-			{
-				case IDENTIFIERS, ROLE_TYPE:
-					continue;
-				case PRACTITIONER_NAMES, ORGANIZATION_NAMES:
-					String nameField = section.equals(ProviderSection.ORGANIZATION_NAMES) ? "Name" : "Surname";
-					String name = page.grabDataBlockContent(section, 0).get(nameField);
-					assertEquals(name, "Confidential", "Surname not set as confidential");
-					continue;
-			}
-            assertEquals(page.grabDataBlockCount(section), 0,
-					"Confidential record data found in section: " + section.name());
-		}
-	}
-
-	// Confidential Record Attribute Search
-	@Test(groups = { "SearchProvider" })
-	public void testConfidentialRecordAttributeSearch()
-	{
-		final PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
-		final IndividualDataGenerator dataGen = IndividualDataGenerator.getInstance();
-
-		// FHIR Prep (if needed)
-		List<MaintainOrgBuilder> orgQuery = fhirController.queryOrganizationByCriteria(
-				new OrgQueryCriteriaParams().setName("ConfidentialRecord"));
-
-		if (orgQuery.isEmpty())
-		{
-			fhirController.createOrganization(new OrganizationMaintainConfig(OrgRoleType.ORG)
-					.withName("ConfidentialRecord").withConfidentiality());
-		}
-
-		List<MaintainIndividualBuilder> indQuery = fhirController.queryIndividualByCriteria(
-				new IndividualQueryCriteriaParams().setFamily("ConfidentialRecord").setExpertise("ENG"));
-
-		if (indQuery.isEmpty())
-		{
-			MaintainIndividualBuilder ind = new IndividualBuilderFactory(dataGen)
-					.build(new IndividualMaintainConfig(IndividualRoleType.MD).withConfidentiality())
-					.familyName("ConfidentialRecord").addExpertise("ENG", dataGen.shortText());
-			fhirController.submitIndividual(ind);
-		}
-
-		SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
-
-		// Search by Criteria
-		provider.searchByCriteria(IndividualRoleType.MD.name(), null, "ConfidentialRecord",
-				null, null, null, null,
-				null, List.of("ENG"));
-		assertEquals(warningList.get("confidentialRecordFound"), provider.grabWarningErrorMessage(),
-				"Expected warning message not found");
-
-		// Search by Organization
-		provider.searchForOrganization(null, "ConfidentialRecord", null,
-				null, null);
-		assertEquals(warningList.get("confidentialRecordFound"), provider.grabWarningErrorMessage(),
-				"Expected warning message not found");
-	}
-
-	// Confidential Record ID Search
-	@Test(groups = { "SearchProvider" })
-	public void testConfidentialRecordIDSearch()
-	{
-		final PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
-
-		// FHIR Prep
-		MaintainIndividualBuilder confidentialInd = fhirController.createIndividual(
-				new IndividualMaintainConfig(IndividualRoleType.MD).withConfidentiality());
-
-		SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
-
-		// Search by Identifier
-		SearchProviderResultsFragment results = provider.searchByIdentifier("IPC",
-				confidentialInd.getIdentifier(IdentifierType.IPC));
-		List<String> resultInfo = results.grabResultsRow(0);
-		assertTrue(Objects.nonNull(resultInfo),
-				"Search by Identifier for confidential record was unsuccessful");
-
-		// Search by Registry Identifier
-		String ipcID = UpdateSimpleHelper.getRegIdString(IdentifierType.IPC.name(),
-				confidentialInd.getIdentifier(IdentifierType.IPC));
-		results = provider.searchByRegistryIdentifier("IPC", ipcID);
-		resultInfo = results.grabResultsRow(0);
-		assertTrue(Objects.nonNull(resultInfo),
-				"Search by Registry Identifier for confidential record was unsuccessful");
-
-		// Search by Criteria / Search by Organization
-		testConfidentialRecordAttributeSearch();
 	}
 
 	// Viewing Permissions for Confidential Provider Records

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
@@ -258,7 +258,7 @@ public class SearchProviderTests implements SimpleTest {
 		        individualAddress.put("line1", getRandomNumber(2,500) + " Oak Avenue");
 		        individualAddress.put("city", "Custom City");
 		        individual.setAddressList(List.of(individualAddress));
-			individual = fhirController.submitIndividual(individual);
+			fhirController.submitIndividual(individual);
 		}
 		// test
 		SearchProviderResultsFragment searchResults = searchProvider.searchByCriteria(IndividualRoleType.DEN.name(), null, null, null,
@@ -284,7 +284,7 @@ public class SearchProviderTests implements SimpleTest {
 			address.put("line1", getRandomNumber(2,500) + " Main St");
 			address.put("city", "Sample City");
 			org.setAddressList(List.of(address));
-			org = fhirController.submitOrganization(org);
+			fhirController.submitOrganization(org);
 		}
 		fhirController.close();
 		//test
@@ -537,25 +537,25 @@ public class SearchProviderTests implements SimpleTest {
 				surname, null, city, null, null);
 		assertTrue(searchResults.grabResultsRowCount() > 0, "search result has too less rows");
 		// step 2
-		searchResults = searchProviderPage.searchByCriteria(roleType.name(), null, null, null, null, null, null);
+		searchProviderPage.searchByCriteria(roleType.name(), null, null, null, null, null, null);
 		String errMsg = searchProviderPage.grabPageErrorMessage();
         assertEquals(errorMissingData, errMsg, "Expected error message not found");
 		searchProviderPage.clearRoleType();
 		// step 3
-		searchResults = searchProviderPage.searchByCriteria(null,null,surname, null,null, null, null);
+		searchProviderPage.searchByCriteria(null,null,surname, null,null, null, null);
 		errMsg = searchProviderPage.grabPageErrorMessage();
         assertEquals(errorMissingData, errMsg, "Expected error message not found");
 		// step 4
-		searchResults = searchProviderPage.searchByCriteria(null, firstname,null, null, null, null, null);
+		searchProviderPage.searchByCriteria(null, firstname,null, null, null, null, null);
 		errMsg = searchProviderPage.grabPageErrorMessage();
         assertEquals(errorMissingData, errMsg, "Expected error message not found");
 		// step 5
-		searchResults = searchProviderPage.searchByCriteria(null, null, null, null, city, null, null);
+		searchProviderPage.searchByCriteria(null, null, null, null, city, null, null);
 		errMsg = searchProviderPage.grabPageErrorMessage();
 		//search with "City Only" will return providers in that city 
 		//assertTrue(errMsg.equals(errorMissingData), "Expected error message not found");
 		// step 6
-		searchResults = searchProviderPage.searchByCriteria(null, null, null, "M", null, null, null);
+		searchProviderPage.searchByCriteria(null, null, null, "M", null, null, null);
 		errMsg = searchProviderPage.grabPageErrorMessage();
         assertEquals(errorMissingData, errMsg, "Expected error message not found");
 		searchProviderPage.clearGender();
@@ -593,27 +593,27 @@ public class SearchProviderTests implements SimpleTest {
 		String cpnString = queriedIndividual.getIdentifier(IdentifierType.CPN);
 		String cpnNum = UpdateSimpleHelper.getRegIdString("CPN", cpnString);
 		// step1
-		SearchProviderResultsFragment searchResults = searchProviderPage.searchByIdentifier(IdentifierType.DENID.name(),
-				null, false);
+		SearchProviderResultsFragment searchResults;
+		searchProviderPage.searchByIdentifier(IdentifierType.DENID.name(), null, false);
 		String errMsg = searchProviderPage.grabPageErrorMessage();
         assertEquals(errorMsgProiderID, errMsg, "Expected error message not found");
 		// step2
 		searchResults = searchProviderPage.searchByIdentifier(IdentifierType.DENID.name(), providerId);
 		assertTrue(searchResults.grabResultsRowCount() > 0);
 		// step3
-		searchResults = searchProviderPage.searchByRegistryIdentifier(IdentifierType.CPN.name(), null, false);
+		searchProviderPage.searchByRegistryIdentifier(IdentifierType.CPN.name(), null, false);
 		errMsg = searchProviderPage.grabPageErrorMessage();
         assertEquals(errorMsgRegIdValue, errMsg, "Expected error message not found");
 		// step4
 		searchResults = searchProviderPage.searchByRegistryIdentifier(IdentifierType.CPN.name(), cpnNum);
 		assertTrue(searchResults.grabResultsRowCount() > 0);
 		// step5
-		searchResults = searchProviderPage.searchByIdentifier("Select One", null, false);
+		searchProviderPage.searchByIdentifier("Select One", null, false);
 		errMsg = searchProviderPage.grabPageErrorMessage();
 		assertTrue(errMsg.contains(errorMsgIdType) && errMsg.contains(errorMsgProiderID),
 				"Expected error messages not found");
 		// step6
-		searchResults = searchProviderPage.searchByRegistryIdentifier("Select One", null, false);
+		searchProviderPage.searchByRegistryIdentifier("Select One", null, false);
 		errMsg = searchProviderPage.grabPageErrorMessage();
 		assertTrue(errMsg.contains(errorMsgRegIdType) && errMsg.contains(errorMsgRegIdValue),
 				"Expected error messages not found");
@@ -644,7 +644,7 @@ public class SearchProviderTests implements SimpleTest {
 				null, addressline1, city);
 		assertTrue(searchResults.grabResultsRowCount() > 0, "search result has too less rows");
 		// Step 2
-		searchResults = searchProviderPage.searchForOrganization(roleType.name(), null, null, null, null);
+		searchProviderPage.searchForOrganization(roleType.name(), null, null, null, null);
 		String errMsg = searchProviderPage.grabPageErrorMessage();
         assertEquals(errorEntryError, errMsg, "Expected error message not found");
 		// Step 3
@@ -678,7 +678,7 @@ public class SearchProviderTests implements SimpleTest {
 			individualAddress.put("line1", getRandomNumber(2, 500) + " Main Avenue");
 			individualAddress.put("city", "Custom City");
 			individual.setAddressList(List.of(individualAddress));
-			individual = fhirController.submitIndividual(individual);
+			fhirController.submitIndividual(individual);
 		}
 		// test
 		
@@ -697,7 +697,7 @@ public class SearchProviderTests implements SimpleTest {
 			address.put("line1", getRandomNumber(2, 500) + " Oak St");
 			address.put("city", "Sample City");
 			org.setAddressList(List.of(address));
-			org = fhirController.submitOrganization(org);
+			fhirController.submitOrganization(org);
 		}
 		fhirController.close();
 		// test
@@ -835,7 +835,7 @@ public class SearchProviderTests implements SimpleTest {
 				desp, city, addressline1);
 		assertTrue(searchResults.grabResultsRowCount() > 0, "search result has too less rows");
 		// test2
-		searchResults = searchProviderPage.searchHDSOrganization(hdsType.name(), null, null, null, null);
+		searchProviderPage.searchHDSOrganization(hdsType.name(), null, null, null, null);
 		String errMsg = searchProviderPage.grabPageErrorMessage();
 		assertTrue(errMsg
 				.contains("The following fields must be supplied: 'Name or Description or Address Line 1 or City'"));

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
@@ -60,7 +60,7 @@ public class SearchProviderTests implements SimpleTest {
 	private final PlrWebWorkflowManager workflowManager_ = new PlrWebWorkflowManager();
 	private static final Config config_ = ConfigProvider.get().getConfig();
     private static final Path errorPath = Path.of(config_.get("data.dir")).resolve("error-list.json");
-    private static JSONObject errorList,warningList;
+    private static JSONObject errorList, warningList, infoList;
 
 	private static FHIRController fhirController;
     
@@ -69,6 +69,7 @@ public class SearchProviderTests implements SimpleTest {
         {
             errorList = new JSONObject(Files.readString(errorPath)).getJSONObject("errors");
             warningList = new JSONObject(Files.readString(errorPath)).getJSONObject("warnings");
+			infoList = new JSONObject(Files.readString(errorPath)).getJSONObject("infos");
         }
         catch (IOException e)
         {
@@ -83,7 +84,7 @@ public class SearchProviderTests implements SimpleTest {
 	@AfterClass
 	private void teardown() {
 		fhirController.close();
-		workflowManager_.logoutAllAndClose();
+		//workflowManager_.logoutAllAndClose();
 		LOG.info("Done.");
 	}
 
@@ -724,44 +725,38 @@ public class SearchProviderTests implements SimpleTest {
 
 	}
 
-// 	Search by HDS is not in ALM yes, need to be added based on Legacy selenium
+	// Search Results Limited by Data Permissions
 	@Test(groups = { "SearchProvider" })
-	public void testSearchHDS() {
-		PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
-		OrganizationMaintainConfig orgConfig = new OrganizationMaintainConfig(OrgRoleType.HDS).withAlias();
-		MaintainOrgBuilder org = fhirController.createOrganization(orgConfig);
-		MaintainOrgBuilder orgQueried = fhirController.queryOrganizationByIdentifier(IdentifierType.IPC,
-				org.getIdentifier(IdentifierType.IPC));
-		fhirController.close();
-		HdsType hdsType = orgQueried.getHdsType();
-		String name = orgQueried.getName();
-		Map<String, String> address = orgQueried.getAddressList().getFirst();
-		String city = address.get("city");
-		String addressline1 = address.get("line1");
-		String desp = orgQueried.getAlias();
-		// test1
-		SearchProviderPage searchProviderPage = workflow.getPlrWebAccessActions().openSearchProvider();
-		SearchProviderResultsFragment searchResults = searchProviderPage.searchHDSOrganization(hdsType.name(), name,
-				desp, city, addressline1);
-		assertTrue(searchResults.grabResultsRowCount() > 0, "search result has too less rows");
-		// test2
-		searchResults = searchProviderPage.searchHDSOrganization(hdsType.name(), null, null, null, null);
-		String errMsg = searchProviderPage.grabPageErrorMessage();
-		assertTrue(errMsg
-				.contains("The following fields must be supplied: 'Name or Description or Address Line 1 or City'"));
-		// test3
-		searchResults = searchProviderPage.searchHDSOrganization(hdsType.name(), name, desp, null, null);
-		assertTrue(searchResults.grabResultsRowCount() > 0, "search result has too less rows");
-		// test4
-		searchResults = searchProviderPage.searchHDSOrganization(hdsType.name(), null, null, city, null);
-		assertTrue(searchResults.grabResultsRowCount() > 0, "search result has too less rows");
-		// test5
-		searchResults = searchProviderPage.searchHDSOrganization(hdsType.name(), null, desp, null, null);
-		assertTrue(searchResults.grabResultsRowCount() > 0, "search result has too less rows");
-		// test 6
-		searchResults = searchProviderPage.searchHDSOrganization(hdsType.name(), null, null, null, addressline1);
-		assertTrue(searchResults.grabResultsRowCount() > 0, "search result has too less rows");
+	public void testSearchResultsDataPermissions()
+	{
+		final PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.CONSUMER);
+		if (!workflow.isLoggedIn()) { workflow.login().openPlr(); }
 
+		final IndividualDataGenerator dataGen = IndividualDataGenerator.getInstance();
+
+		// FHIR Prep - create providers outside of Consumer's data permission scope
+		List<MaintainIndividualBuilder> optQuery = fhirController.queryIndividualByCriteria(
+				new IndividualQueryCriteriaParams()
+						.setRoleType(IndividualRoleType.OPT).setFamily("TestScopeOpt").setExpertise("ENG"));
+
+		if (optQuery.isEmpty())
+		{
+			MaintainIndividualBuilder ind = new IndividualBuilderFactory(dataGen)
+					.build(new IndividualMaintainConfig(IndividualRoleType.OPT))
+					.familyName("TestScopeOpt").addExpertise("ENG", dataGen.shortText());
+			fhirController.submitIndividual(ind);
+		} else {
+			optQuery.getFirst();
+		}
+
+		SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
+		SearchProviderResultsFragment results = provider.searchByCriteria(null, null,
+				"TestScopeOpt", null, null, null, null,
+				null, List.of("ENG"));
+		assertEquals(results.grabResultsRowCount(), 0,
+				"Search results returned records outside of data permission scope unexpectedly");
+		assertEquals(provider.grabInfoMessage(), infoList.get("permissionRules"),
+				"Permission info message not found");
 	}
 
 	// Viewing Permissions for Confidential Provider Records
@@ -817,5 +812,45 @@ public class SearchProviderTests implements SimpleTest {
 
 		// checking secondary
 		testConfidentialMask(providerType, isOrganization ? confOrg : confInd);
+	}
+
+// 	Search by HDS is not in ALM yes, need to be added based on Legacy selenium
+	@Test(groups = { "SearchProvider" })
+	public void testSearchHDS() {
+		PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
+		OrganizationMaintainConfig orgConfig = new OrganizationMaintainConfig(OrgRoleType.HDS).withAlias();
+		MaintainOrgBuilder org = fhirController.createOrganization(orgConfig);
+		MaintainOrgBuilder orgQueried = fhirController.queryOrganizationByIdentifier(IdentifierType.IPC,
+				org.getIdentifier(IdentifierType.IPC));
+		fhirController.close();
+		HdsType hdsType = orgQueried.getHdsType();
+		String name = orgQueried.getName();
+		Map<String, String> address = orgQueried.getAddressList().getFirst();
+		String city = address.get("city");
+		String addressline1 = address.get("line1");
+		String desp = orgQueried.getAlias();
+		// test1
+		SearchProviderPage searchProviderPage = workflow.getPlrWebAccessActions().openSearchProvider();
+		SearchProviderResultsFragment searchResults = searchProviderPage.searchHDSOrganization(hdsType.name(), name,
+				desp, city, addressline1);
+		assertTrue(searchResults.grabResultsRowCount() > 0, "search result has too less rows");
+		// test2
+		searchResults = searchProviderPage.searchHDSOrganization(hdsType.name(), null, null, null, null);
+		String errMsg = searchProviderPage.grabPageErrorMessage();
+		assertTrue(errMsg
+				.contains("The following fields must be supplied: 'Name or Description or Address Line 1 or City'"));
+		// test3
+		searchResults = searchProviderPage.searchHDSOrganization(hdsType.name(), name, desp, null, null);
+		assertTrue(searchResults.grabResultsRowCount() > 0, "search result has too less rows");
+		// test4
+		searchResults = searchProviderPage.searchHDSOrganization(hdsType.name(), null, null, city, null);
+		assertTrue(searchResults.grabResultsRowCount() > 0, "search result has too less rows");
+		// test5
+		searchResults = searchProviderPage.searchHDSOrganization(hdsType.name(), null, desp, null, null);
+		assertTrue(searchResults.grabResultsRowCount() > 0, "search result has too less rows");
+		// test 6
+		searchResults = searchProviderPage.searchHDSOrganization(hdsType.name(), null, null, null, addressline1);
+		assertTrue(searchResults.grabResultsRowCount() > 0, "search result has too less rows");
+
 	}
 }

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
@@ -49,6 +49,7 @@ import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflowManager;
 import ca.bc.gov.health.qa.autotest.runner.util.log.ExecutionLogManager;
 import ca.bc.gov.health.qa.autotest.runner.util.testng.SimpleTest;
 
+/** Tests class for the Search Provider page */
 public class SearchProviderTests implements SimpleTest {
 	private static final Logger LOG = ExecutionLogManager.getLogger();
 
@@ -60,7 +61,6 @@ public class SearchProviderTests implements SimpleTest {
 	private static FHIRController fhirController;
     
 	private SearchProviderTests() {
-		
 		try
         {
             errorList = new JSONObject(Files.readString(errorPath)).getJSONObject("errors");
@@ -77,13 +77,13 @@ public class SearchProviderTests implements SimpleTest {
 	private final String NORECORDFOUND = "No records found.";
 
 	@AfterClass
-	public void teardown() {
+	private void teardown() {
 		workflowManager_.logoutAllAndClose();
 		LOG.info("Done.");
 	}
 
 	@BeforeMethod
-	public void before(Object[] parameters) {
+	private void before(Object[] parameters) {
 		PlrWebWorkflow workflow = workflowManager_.selectWorkflow(parameters, UserType.ADMIN);
 		if (!workflow.isLoggedIn()) {
 			workflow.login().openPlr();
@@ -91,7 +91,7 @@ public class SearchProviderTests implements SimpleTest {
 	}
 
 	@BeforeTest
-	public void beforeTest() {
+	private void beforeTest() {
 		fhirController = new FHIRController(UserType.ADMIN);
 	}
 

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
@@ -7,16 +7,10 @@ import static org.testng.Assert.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.query.IndividualQueryCriteriaParams;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.query.OrgQueryCriteriaParams;
-import ca.bc.gov.health.qa.autotest.plr.web.actions.provider.SearchProviderActions;
-import ca.bc.gov.health.qa.autotest.plr.web.pages.common.AlertMessagesFragment;
-import ca.bc.gov.health.qa.autotest.plr.web.tests.TestHelper;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 import org.testng.annotations.AfterClass;
@@ -597,5 +591,36 @@ public class SearchProviderTests implements SimpleTest {
 				null, null);
 		assertEquals(warningList.get("confidentialRecordFound"), provider.grabWarningErrorMessage(),
 				"Expected warning message not found");
+	}
+
+	// Confidential Record ID Search
+	@Test(groups = { "SearchProvider" })
+	public void testConfidentialRecordIDSearch()
+	{
+		final PlrWebWorkflow workflow = workflowManager_.getSelectedWorkflow();
+
+		// FHIR Prep
+		MaintainIndividualBuilder confidentialInd = fhirController.createIndividual(
+				new IndividualMaintainConfig().withConfidentiality());
+
+		SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
+
+		// Search by Identifier
+		SearchProviderResultsFragment results = provider.searchByIdentifier("IPC",
+				confidentialInd.getIdentifier(IdentifierType.IPC));
+		List<String> resultInfo = results.grabResultsRow(0);
+		assertTrue(Objects.nonNull(resultInfo),
+				"Search by Identifier for confidential record was unsuccessful");
+
+		// Search by Registry Identifier
+		String ipcID = UpdateSimpleHelper.getRegIdString(IdentifierType.IPC.name(),
+				confidentialInd.getIdentifier(IdentifierType.IPC));
+		results = provider.searchByRegistryIdentifier("IPC", ipcID);
+		resultInfo = results.grabResultsRow(0);
+		assertTrue(Objects.nonNull(resultInfo),
+				"Search by Registry Identifier for confidential record was unsuccessful");
+
+		// Search by Criteria / Search by Organization
+		testConfidentialRecordAttributeSearch();
 	}
 }

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/SearchProviderTests.java
@@ -9,8 +9,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 
+import ca.bc.gov.health.qa.autotest.plr.data.InjectableData;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.query.IndividualQueryCriteriaParams;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.query.OrgQueryCriteriaParams;
+import ca.bc.gov.health.qa.autotest.plr.util.ProviderType;
+import ca.bc.gov.health.qa.autotest.plr.web.actions.provider.SearchProviderActions;
+import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.ProviderSection;
+import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.ViewProviderPage;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 import org.testng.annotations.AfterClass;
@@ -79,7 +84,6 @@ public class SearchProviderTests implements SimpleTest {
 
 	@BeforeMethod
 	public void before(Object[] parameters) {
-
 		PlrWebWorkflow workflow = workflowManager_.selectWorkflow(parameters, UserType.ADMIN);
 		if (!workflow.isLoggedIn()) {
 			workflow.login().openPlr();
@@ -549,6 +553,61 @@ public class SearchProviderTests implements SimpleTest {
 
 	}
 
+	// Confidential Mask
+	@Test(groups = { "SearchProvider" }, dataProvider = "indOrgTypes", dataProviderClass = InjectableData.class)
+	public void testConfidentialMask(ProviderType providerType)
+	{
+		final PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.SECONDARY);
+		if (!workflow.isLoggedIn()) { workflow.login().openPlr(); }
+		final SearchProviderActions actions = workflowManager_.getSelectedWorkflow().getSearchProviderActions();
+
+		// FHIR Prep
+		MaintainIndividualBuilder confInd = null;
+		MaintainOrgBuilder confOrg = null;
+		switch (providerType)
+		{
+			case BC_PRACTITIONER -> confInd = fhirController.createIndividual(
+					new IndividualMaintainConfig(IndividualRoleType.MD).withConfidentiality());
+            case ORGANIZATION -> confOrg = fhirController.createOrganization(
+					new OrganizationMaintainConfig(OrgRoleType.ORG).withConfidentiality());
+			default -> throw new IllegalStateException("Unsupported provider type " + providerType.name());
+        }
+		boolean isOrganization = !Objects.isNull(confOrg);
+
+		// Test Start
+		SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
+
+		String identifier;
+		if (isOrganization) identifier = confOrg.getIdentifier(IdentifierType.IPC);
+		else identifier = confInd.getIdentifier(IdentifierType.IPC);
+
+		SearchProviderResultsFragment results = provider.searchByIdentifier("IPC", identifier);
+		List<String> resultInfo = results.grabResultsRow(0);
+		assertEquals(resultInfo.getFirst(), "Link to View Provider", "Record name not confidentially masked");
+
+		ViewProviderPage page = actions.openSearchResults(0);
+
+		assertEquals(page.getViewHeader().grabViewTitle().split(" ")[0], "Confidential",
+				"Record name in title not confidentially masked");
+
+		// Verify confidential sections are masked
+		for (ProviderSection section : ProviderSection.getProviderSectionSet(providerType))
+		{
+			switch (section)
+			{
+				case IDENTIFIERS, ROLE_TYPE:
+					continue;
+				case PRACTITIONER_NAMES, ORGANIZATION_NAMES:
+					String nameField = section.equals(ProviderSection.ORGANIZATION_NAMES) ? "Name" : "Surname";
+					String name = page.grabDataBlockContent(section, 0).get(nameField);
+					assertEquals(name, "Confidential", "Surname not set as confidential");
+					continue;
+			}
+            assertEquals(page.grabDataBlockCount(section), 0,
+					"Confidential record data found in section: " + section.name());
+		}
+	}
+
 	// Confidential Record Attribute Search
 	@Test(groups = { "SearchProvider" })
 	public void testConfidentialRecordAttributeSearch()
@@ -601,7 +660,7 @@ public class SearchProviderTests implements SimpleTest {
 
 		// FHIR Prep
 		MaintainIndividualBuilder confidentialInd = fhirController.createIndividual(
-				new IndividualMaintainConfig().withConfidentiality());
+				new IndividualMaintainConfig(IndividualRoleType.MD).withConfidentiality());
 
 		SearchProviderPage provider = workflow.getPlrWebAccessActions().openSearchProvider();
 

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/ViewProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/ViewProviderTests.java
@@ -48,8 +48,7 @@ public class ViewProviderTests implements SimpleTest
     private final Map<ProviderType, MaintainRequestBuilder> defaultProviders = new LinkedHashMap<>();
     private final Map<ProviderType, MaintainRequestBuilder> minimumProviders = new LinkedHashMap<>();
 
-    public ViewProviderTests()
-    {}
+    private ViewProviderTests() {}
 
     @AfterClass
     private void teardown()


### PR DESCRIPTION
This PR implements all Search Provider Tests in scope for my ticket. Some details/considerations are below:

The Searching Incorrect Data test case uses an expected name to search for both an organization and individual and will create new providers that use the name if one is not found. It also modifies this name as part of the test case and will cleanup the providers afterwards by resetting the name back to its original state. As such, unexpected behaviour may occur if the test case cleanup is interrupted (particularly in future runs of the test case)

Submitting an individual with demographics requires the birth country to be set to a country code, but an individual retrieved from a query would contain the birth country demographic data as the full name of the country instead of a country code, causing issues when attempting to update the individual through FHIR. The most recent commit to this branch fixes this by changing the most common country (CANADA) to its country code (CA) within the individual data when it is built, but this may have consequences for previous View Provider test cases and does not cover any other countries.