### PR TITLE
Feature/plr-564 - Validate Organization Name (Add+Update)

### DIFF
--- a/autotest-plr/data/error-list.json
+++ b/autotest-plr/data/error-list.json
@@ -115,8 +115,9 @@
     "errorInvCharsPayeeNumber": "GRS.PRV.PRO.MTN.1.0.9017: Invalid characters entered: Payee Number.",
     "errorDuplicatePayeeNumber": "GRS.SYS.UNK.UNK.1.0.7093: Cannot create duplicate Payee Number",
     "errorDuplicateHdsSubType": "GRS.SYS.UNK.UNK.1.0.7093: Cannot create duplicate HDS Sub Type",
-    "errorInvalidChar7081" : "GRS.SYS.ELE.UNK.1.0.7081: Invalid characters entered."
-
+    "errorInvalidChar7081" : "GRS.SYS.ELE.UNK.1.0.7081: Invalid characters entered.",
+    "errorNameTooLong": "GRS.SYS.UNK.UNK.1.0.5003: Entry Error. 'Name' length must be between 1 and 100. Your transaction has not been processed. Correct and resubmit.",
+    "errorLongNameTooLong": "GRS.SYS.UNK.UNK.1.0.5003: Entry Error. 'Long Name' length must be between 0 and 200. Your transaction has not been processed. Correct and resubmit."
   },
   "warnings": {
     "missingCriteria": "Invalid or Incomplete form data provided, please see instructions on the right side.",

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateOrganizationPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateOrganizationPage.java
@@ -4,10 +4,13 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
+import ca.bc.gov.health.qa.autotest.plr.web.tests.helper.UpdateSimpleHelper;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.provider.IdType;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.provider.OrgNameType;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.provider.RegIdType;
+import ca.bc.gov.health.qa.autotest.runner.util.log.ExecutionLogManager;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.By;
 import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.StaleElementReferenceException;
@@ -25,6 +28,8 @@ import ca.bc.gov.health.qa.autotest.runner.util.selenium.SeleniumSession;
  * with specific functionality for Organization Properties section
  */
 public class UpdateOrganizationPage extends UpdateProviderPage {
+
+	private static final Logger LOG = ExecutionLogManager.getLogger();
 
 	/**
 	 * Enhanced DIALOG_MAP that includes parent's entries plus ORGANIZATION_PROPERTIES.
@@ -111,8 +116,8 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 			dialogCss = getOrgDialogCss(section);
 		} else {
 			// For other sections, use parent's DIALOG_MAP directly
-			String dialogName = UpdateProviderPage.DIALOG_MAP.get(section).getDialogName();
-			String formName = UpdateProviderPage.DIALOG_MAP.get(section).getFormName();
+			String dialogName = DIALOG_MAP.get(section).getDialogName();
+			String formName = DIALOG_MAP.get(section).getFormName();
 			dialogCss = "div#" + dialogName + " > div#" + dialogName + "_content" + " > form#" + formName;
 		}
 			
@@ -245,7 +250,7 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 	 * wait Error Message showing up, and return a copy of message as result
 	 * note the result is a set of messages, if there are more than one error messages
 	 *
-	 * @param section
+	 * @param section the provider section
 	 * @return String of error messages
 	 */
 	public String waitErrorMessage(ProviderSection section) {
@@ -256,6 +261,7 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 			waitSeconds(5);
 			try {
 				msgDisplay = getDialogMessages(section);
+				LOG.info(msgDisplay);
 			} catch (StaleElementReferenceException e) {
 				waitSeconds(5);
 			}
@@ -465,9 +471,10 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 	 * @param nameType the organization name type
 	 * @param name the organization name
 	 * @param description the organization description
+	 * @param expectError whether an error is anticipated
 	 * @return the full message dialog of errors, if any exist. otherwise an empty string
 	 */
-	public String addOrganizationNameDataBlock(OrgNameType nameType, String name, String description) {
+	public String addOrganizationNameDataBlock(OrgNameType nameType, String name, String description, boolean expectError) {
 		String msgDisplay = "";
 		String formName = DIALOG_MAP.get(ProviderSection.ORGANIZATION_NAMES).getFormName();
 		String dialogCss = getOrgDialogCss(ProviderSection.ORGANIZATION_NAMES);
@@ -487,14 +494,13 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 		// Set Description field
 		findAndFillOrgInputField(dialogCss, formName, description, "longName");
 
-		clickOrgDialogSubmitButton(ProviderSection.ORGANIZATION_NAMES);
+		setOrgDialogEffectiveFromAndEffectiveTo(ProviderSection.ORGANIZATION_NAMES,
+				UpdateSimpleHelper.effective_date(), UpdateSimpleHelper.increment_year_for_effective_date());
 
-		msgDisplay = getDialogMessages(ProviderSection.ORGANIZATION_NAMES);
+		clickOrgDialogSubmitButton(ProviderSection.ORGANIZATION_NAMES, expectError);
 
-		if (!StringUtils.isEmpty(msgDisplay)) {
-			WebElement cancelButton = selenium_.findElement(By.linkText("Cancel"));
-			cancelButton.click();
-		}
+		if(expectError)
+			msgDisplay=waitErrorMessage(ProviderSection.CONDITIONS);
 
 		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
 		return msgDisplay;

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateOrganizationPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateOrganizationPage.java
@@ -3,6 +3,7 @@ package ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import ca.bc.gov.health.qa.autotest.plr.web.tests.helper.UpdateSimpleHelper;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.provider.IdType;
@@ -78,7 +79,7 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 				.waitUntil(ExpectedConditions.elementToBeClickable(By.cssSelector(clickElementCss)));
 		selenium_.scrollIntoView(clickElement);
 		try {
-			clickElement.click();
+			Objects.requireNonNull(clickElement).click();
 		} catch (StaleElementReferenceException | ElementClickInterceptedException e) {
 			waitSeconds(2);
 			clickElement = selenium_.findElement(By.cssSelector(clickElementCss));
@@ -99,8 +100,8 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 	@Override
 	public void clickDataBlockUpdateButton(ProviderSection section, int index) {
 		String selectCss = getDataBlockHeaderUpdateButtonSelector(section, index);
-		WebElement updateButton = selenium_.waitUntil(ExpectedConditions
-				.elementToBeClickable(By.cssSelector(selectCss)));
+		selenium_.waitUntil(ExpectedConditions.elementToBeClickable(By.cssSelector(selectCss)));
+		WebElement updateButton = selenium_.findElementByCss(selectCss);
 		selenium_.scrollIntoView(updateButton);
 
 		try {
@@ -136,14 +137,16 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 		
 		// Click the datepicker trigger button
 		String triggerButtonCss = "span#" + formName + "\\:" + effectiveFromStr + " > button.ui-datepicker-trigger";
-		selenium_.waitUntil(ExpectedConditions.elementToBeClickable(By.cssSelector(triggerButtonCss))).click();
+		selenium_.waitUntil(ExpectedConditions.elementToBeClickable(By.cssSelector(triggerButtonCss)));
+		selenium_.findElementByCss(triggerButtonCss).click();
 		
 		// Wait for datepicker to appear and click the "Today" button
 		By datepickerLocator = By.cssSelector("div#ui-datepicker-div");
 		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(datepickerLocator));
 		
 		By todayButtonLocator = By.cssSelector("button.ui-datepicker-current");
-		selenium_.waitUntil(ExpectedConditions.elementToBeClickable(todayButtonLocator)).click();
+		selenium_.waitUntil(ExpectedConditions.elementToBeClickable(todayButtonLocator));
+		selenium_.findElement(todayButtonLocator).click();
 		
 		// Get the value from the input field
 		String inputCss = "input#" + formName + "\\:" + effectiveFromStr + "_input";
@@ -254,9 +257,7 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 	 * @return String of error messages
 	 */
 	public String waitErrorMessage(ProviderSection section) {
-		String msgDisplay = "";
-
-		msgDisplay = getDialogMessages(section);
+		String msgDisplay = getDialogMessages(section);
 		while (StringUtils.isEmpty(msgDisplay)) {
 			waitSeconds(5);
 			try {
@@ -284,7 +285,8 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 	private void findAndFillOrgInputField(String dialogCss, String formName, String field, String fieldCss) {
 		String inputNameCss = dialogCss + " >input#" + formName + "\\:" + fieldCss;
 		// Wait for the input field to be visible
-		WebElement inputName = selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(inputNameCss)));
+		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(inputNameCss)));
+		WebElement inputName = selenium_.findElementByCss(inputNameCss);
         waitSeconds(1);
 
 		inputName.clear();
@@ -303,7 +305,8 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 	private void findAndFillOrgTextAreaField(String dialogCss, String formName, String field, String fieldCss) {
 		String textAreaCss = dialogCss + " >textarea#" + formName + "\\:" + fieldCss;
 		// Wait for the textarea field to be visible
-		WebElement textArea = selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(textAreaCss)));
+		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(textAreaCss)));
+		WebElement textArea = selenium_.findElementByCss(textAreaCss);
         waitSeconds(1);
 
 		textArea.clear();
@@ -351,12 +354,15 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 	private void setOrgCheckboxValue(String dialogCss, String formName, String fieldCss, boolean checked) {
 		// First try selectBooleanButton (used by PCI Flag)
 		String buttonCss = dialogCss + " > div#" + formName + "\\:" + fieldCss;
-		WebElement buttonElement = selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(buttonCss)));
+		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(buttonCss)));
+		WebElement buttonElement = selenium_.findElement(By.cssSelector(buttonCss));
 		waitSeconds(1);
 
+		String btnClass = buttonElement.getAttribute("class");
+
 		// Check if it's a selectBooleanButton
-		if (buttonElement.getAttribute("class").contains("ui-selectbooleanbutton")) {
-			boolean isChecked = buttonElement.getAttribute("class").contains("ui-state-active");
+		if (btnClass != null && btnClass.contains("ui-selectbooleanbutton")) {
+			boolean isChecked = btnClass.contains("ui-state-active");
 			
 			// Only click if the state needs to change
 			if (isChecked != checked) {
@@ -366,8 +372,13 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 			// Handle regular checkbox
 			String checkboxCss = buttonCss + " > div.ui-chkbox-box";
 			WebElement checkbox = selenium_.findElement(By.cssSelector(checkboxCss));
-			
-			boolean isChecked = checkbox.getAttribute("class").contains("ui-state-active");
+			String chkClass = checkbox.getAttribute("class");
+
+			// default is to click (in the event of an unlikely null pointer)
+			boolean isChecked = !checked;
+
+			if (chkClass != null)
+				isChecked = chkClass.contains("ui-state-active");
 			
 			// Only click if the state needs to change
 			if (isChecked != checked) {
@@ -401,7 +412,6 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 	 * @return the full message dialog of errors, if any exist. otherwise an empty string
 	 */
 	public String addRegistryIdentifierDataBlock(RegIdType identifierType, String identifier) {
-		String msgDisplay = "";
 		String formName = DIALOG_MAP.get(ProviderSection.REGISTRY_IDENTIFIERS).getFormName();
 		String dialogCss = getOrgDialogCss(ProviderSection.REGISTRY_IDENTIFIERS);
 
@@ -419,7 +429,7 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 
 		clickOrgDialogSubmitButton(ProviderSection.REGISTRY_IDENTIFIERS);
 
-		msgDisplay = getDialogMessages(ProviderSection.REGISTRY_IDENTIFIERS);
+		String msgDisplay = getDialogMessages(ProviderSection.REGISTRY_IDENTIFIERS);
 
 		if (!StringUtils.isEmpty(msgDisplay)) {
 			WebElement cancelButton = selenium_.findElement(By.linkText("Cancel"));
@@ -437,7 +447,6 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 	 * @return the full message dialog of errors, if any exist. otherwise an empty string
 	 */
 	public String addIdentifierDataBlock(IdType identifierType, String identifier) {
-		String msgDisplay = "";
 		String formName = DIALOG_MAP.get(ProviderSection.IDENTIFIERS).getFormName();
 		String dialogCss = getOrgDialogCss(ProviderSection.IDENTIFIERS);
 
@@ -455,7 +464,7 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 
 		clickOrgDialogSubmitButton(ProviderSection.IDENTIFIERS);
 
-		msgDisplay = getDialogMessages(ProviderSection.IDENTIFIERS);
+		String msgDisplay = getDialogMessages(ProviderSection.IDENTIFIERS);
 
 		if (!StringUtils.isEmpty(msgDisplay)) {
 			WebElement cancelButton = selenium_.findElement(By.linkText("Cancel"));
@@ -516,7 +525,7 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 	 * @return the full message dialog of errors, if any exist. otherwise an empty string
 	 */
 	public String addOrganizationPropertyDataBlock(OrganizationProperties propertyType, String propertyValue, String effectiveFrom, String effectiveTo) {
-		String msgDisplay = "";
+		String msgDisplay;
 		String formName = DIALOG_MAP.get(ProviderSection.ORGANIZATION_PROPERTIES).getFormName();
 		String dialogCss = getOrgDialogCss(ProviderSection.ORGANIZATION_PROPERTIES);
 
@@ -771,9 +780,7 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 	 * @return String of error messages
 	 */
 	public String waitOrgErrorMessage(ProviderSection section) {
-		String msgDisplay = "";
-
-		msgDisplay = getDialogMessages(section);
+		String msgDisplay = getDialogMessages(section);
 		while (StringUtils.isEmpty(msgDisplay)) {
 			waitSeconds(5);
 			try {

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -7,7 +7,9 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
+import ca.bc.gov.health.qa.autotest.runner.util.log.ExecutionLogManager;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.By;
 import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.JavascriptExecutor;
@@ -22,6 +24,8 @@ import ca.bc.gov.health.qa.autotest.runner.util.selenium.SeleniumExpectedConditi
 import ca.bc.gov.health.qa.autotest.runner.util.selenium.SeleniumSession;
 
 public class UpdateProviderPage extends ViewProviderPage {
+
+	private static final Logger LOG = ExecutionLogManager.getLogger();
 
 	public static final Map<ProviderSection, ProviderDialog> DIALOG_MAP = Map.of(
 			ProviderSection.REGISTRY_IDENTIFIERS, new ProviderDialog("maintainRegIdDialog", "maintainRegIdForm", "effectiveStartDate",
@@ -495,7 +499,7 @@ public class UpdateProviderPage extends ViewProviderPage {
 		try {
 			java.util.List<WebElement> msgList = selenium_.findElements(By.cssSelector(msgCss));
 			for (WebElement msg : msgList) {
-				msgDisplay += msg.getText() + "\n";
+				msgDisplay += msg.getAttribute("innerText") + "\n";
 			}
 		} catch (Exception e) {
 			// No messages found

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateOrganizationTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateOrganizationTests.java
@@ -55,7 +55,7 @@ public class UpdateOrganizationTests implements SimpleTest {
 
     @AfterClass
     public void teardown() {
-        //workflowManager_.logoutAllAndClose();
+        workflowManager_.logoutAllAndClose();
         LOG.info("Done.");
     }
 

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateOrganizationTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateOrganizationTests.java
@@ -1,0 +1,141 @@
+package ca.bc.gov.health.qa.autotest.plr.web.tests.provider;
+
+import static ca.bc.gov.health.qa.autotest.plr.web.tests.TestHelper.*;
+import static org.testng.Assert.assertEquals;
+
+import ca.bc.gov.health.qa.autotest.core.util.config.Config;
+import ca.bc.gov.health.qa.autotest.core.util.config.ConfigProvider;
+import ca.bc.gov.health.qa.autotest.plr.fhir.FHIRController;
+import ca.bc.gov.health.qa.autotest.plr.fhir.data.organization.OrganizationMaintainConfig;
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.common.model.IdentifierType;
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.MaintainOrgBuilder;
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.model.OrgRoleType;
+import ca.bc.gov.health.qa.autotest.plr.util.UserType;
+import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.ProviderSection;
+import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.UpdateOrganizationPage;
+import ca.bc.gov.health.qa.autotest.plr.web.tests.model.EndReason;
+import ca.bc.gov.health.qa.autotest.plr.web.tests.model.provider.OrgNameType;
+import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflow;
+import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflowManager;
+import ca.bc.gov.health.qa.autotest.runner.util.log.ExecutionLogManager;
+import ca.bc.gov.health.qa.autotest.runner.util.testng.SimpleTest;
+import org.apache.logging.log4j.Logger;
+import org.json.JSONObject;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+public class UpdateOrganizationTests implements SimpleTest {
+    private static final Logger LOG = ExecutionLogManager.getLogger();
+
+    private final PlrWebWorkflowManager workflowManager_ = new PlrWebWorkflowManager();
+    private static final Config config_ = ConfigProvider.get().getConfig();
+    private static final Path errorPath = Path.of(config_.get("data.dir")).resolve("error-list.json");
+    public static JSONObject errorList;
+    String defaultOrg;
+
+    private UpdateOrganizationTests()
+    {
+        try
+        {
+            errorList = new JSONObject(Files.readString(errorPath)).getJSONObject("errors");
+        }
+        catch (IOException e)
+        {
+            String msg = String.format("Failed to read JSON data (%s).", errorPath);
+            throw new IllegalStateException(msg, e);
+        }
+    }
+
+    @AfterClass
+    public void teardown() {
+        //workflowManager_.logoutAllAndClose();
+        LOG.info("Done.");
+    }
+
+    @BeforeMethod
+    public void before(Object[] parameters) {
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
+        if (!workflow.isLoggedIn()) {
+            workflow.login().openPlr();
+        }
+    }
+
+    @BeforeTest
+    public void beforeTest() {
+        FHIRController fhirController = new FHIRController(UserType.ADMIN);
+
+        MaintainOrgBuilder org = fhirController.createOrganization(new OrganizationMaintainConfig(OrgRoleType.ORG));
+        defaultOrg = org.getIdentifier(IdentifierType.IPC);
+
+        fhirController.close();
+    }
+
+    // Update Provider - Validate Organization Name (Add)
+    @Test
+    public void testValidateOrgNameAdd() {
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
+
+        UpdateOrganizationPage page = viewByIdentifierAsUpdateOrg(defaultOrg, workflowManager_);
+
+        String error = page.addOrganizationNameDataBlock(OrgNameType.CURR, "", "Test Desc", true);
+
+        assertEquals(error, errorList.get("errorMsgName"), "Error message did not match expected value.");
+
+        error = page.addOrganizationNameDataBlock(OrgNameType.CURR, generateAlphabetString(101), "Test Desc", true);
+
+        assertEquals(error, errorList.get("errorNameTooLong"), "Error message did not match expected value.");
+
+        error = page.addOrganizationNameDataBlock(OrgNameType.CURR, "Test Name", generateAlphabetString(201), true);
+
+        assertEquals(error, errorList.get("errorLongNameTooLong"), "Error message did not match expected value.");
+
+        error = page.addOrganizationNameDataBlock(OrgNameType.CURR, generateAlphabetString(101), generateAlphabetString(201), true);
+
+        assertEquals(error, errorList.get("errorNameTooLong") + "\n" + errorList.get("errorLongNameTooLong"),
+                "Did not receive expected multiple errors.");
+
+        final String expectedName = generateAlphabetString(100);
+        final String expectedDesc = generateAlphabetString(200);
+
+        page.addOrganizationNameDataBlock(OrgNameType.CURR, expectedName, expectedDesc, false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ORGANIZATION_NAMES, true), 2,
+                "Expected 2 active data blocks after adding valid organization name.");
+    }
+
+    // Update Provider - Validate Organization Name (Update)
+    @Test
+    public void testValidateOrgNameUpdate() {
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
+
+        UpdateOrganizationPage page = viewByIdentifierAsUpdateOrg(defaultOrg, workflowManager_);
+
+        String error = page.updateOrganizationNameDataBlock("", "Test Desc", EndReason.CHG, 0, true);
+
+        assertEquals(error, errorList.get("errorMsgName"), "Error message did not match expected value.");
+
+        error = page.updateOrganizationNameDataBlock(generateAlphabetString(101), "Test Desc", EndReason.CHG, 0, true);
+
+        assertEquals(error, errorList.get("errorNameTooLong"), "Error message did not match expected value.");
+
+        error = page.updateOrganizationNameDataBlock("Test Name", generateAlphabetString(201), EndReason.CHG, 0, true);
+
+        assertEquals(error, errorList.get("errorLongNameTooLong"), "Error message did not match expected value.");
+
+        final String expectedName = generateAlphabetString(100);
+        final String expectedDesc = generateAlphabetString(200);
+
+        page.updateOrganizationNameDataBlock(expectedName, expectedDesc, EndReason.CHG, 0, false);
+
+        Map<String,String> orgName = page.grabDataBlockContent(ProviderSection.ORGANIZATION_NAMES, 0);
+        assertEquals(orgName.get("Name"), expectedName, "Organization name was not updated as expected.");
+        assertEquals(orgName.get("Description"), expectedDesc, "Organization long name was not updated as expected.");
+    }
+}

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
@@ -64,7 +64,7 @@ public class UpdateProviderTests implements SimpleTest {
 
     @AfterClass
     public void teardown() {
-    	 workflowManager_.logoutAllAndClose();
+        workflowManager_.logoutAllAndClose();
         LOG.info("Done.");
     }
 


### PR DESCRIPTION
This PR implements checking adding a new organization name and updating an already existing organization name. It relies on a FHIR-generated org to create an organization name.

The data organization is not ideal in my opinion (organization name dialog information is in the parent UpdateProviderPage instead of UpdateOrganizationPage) but it seemed like keeping it the way it is now would prevent duplicating code unnecessarily.