### PR TITLE
Feature/plr 565

### DIFF
--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -349,7 +349,7 @@ public class UpdateProviderPage extends ViewProviderPage {
 		waitSeconds(2); // Wait for province field to update after country change
 	}
 
-	/**
+		/**
 	 * Click Dialog Submit Button
 	 *
 	 * @param section the provider section
@@ -370,8 +370,8 @@ public class UpdateProviderPage extends ViewProviderPage {
 		String submitButtonName = DIALOG_MAP.get(section).getSubmitButtonName();
 		String dialogCss = getDialogCss(section);
 
-		// Use descendant selector (space) instead of direct child (>) to handle nested div structures
-		String buttonCss = dialogCss + " div.formControls" + " button#" + formName + "\\:" + submitButtonName;
+		// Use a selector that matches any button whose id starts with the expected button name
+		String buttonCss = dialogCss + " div.formControls button[id^='" + formName + ":" + submitButtonName + "']";
 		WebElement button = selenium_.findElement(By.cssSelector(buttonCss));
 		button.click();
 		waitSeconds(2);

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -4,13 +4,18 @@ import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.fail;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -19,10 +24,14 @@ import ca.bc.gov.health.qa.autotest.core.util.net.UriUtils;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.components.AutocompleteMenu;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.components.DropDownMenu;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.EndReason;
+import ca.bc.gov.health.qa.autotest.plr.web.tests.model.TelecommunicationPurpose;
 import ca.bc.gov.health.qa.autotest.runner.util.selenium.SeleniumExpectedConditions;
 import ca.bc.gov.health.qa.autotest.runner.util.selenium.SeleniumSession;
 
 public class UpdateProviderPage extends ViewProviderPage {
+
+	/** Pattern to extract codes from displayed format "Description (CODE)" */
+	private static final Pattern CODE_IN_PARENS_PATTERN = Pattern.compile("\\(([^)]+)\\)$");
 
 	public static final Map<ProviderSection, ProviderDialog> DIALOG_MAP = Map.ofEntries(
 			Map.entry(ProviderSection.REGISTRY_IDENTIFIERS, new ProviderDialog("maintainRegIdDialog", "maintainRegIdForm", "effectiveStartDate",
@@ -330,6 +339,17 @@ public class UpdateProviderPage extends ViewProviderPage {
 	}
 
 	/**
+	 * Sets the address country dropdown value and waits for UI to update.
+	 * This is useful when testing province dropdown changes based on country selection.
+	 *
+	 * @param country the country value to select (e.g., "CA - CANADA", "US - UNITED STATES")
+	 */
+	public void setAddressCountry(String country) {
+		setDropdownListByVisibleText(ProviderSection.ADDRESSES, "country", country);
+		waitSeconds(2); // Wait for province field to update after country change
+	}
+
+	/**
 	 * Click Dialog Submit Button
 	 *
 	 * @param section the provider section
@@ -436,10 +456,13 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 		clickDialogSubmitButton(ProviderSection.DISCIPLINARY_ACTIONS, expectError);
 
-		if (expectError)
+		if (expectError) {
 			msgDisplay = waitErrorMessage(ProviderSection.DISCIPLINARY_ACTIONS);
-
-		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+			// Cancel the dialog since it stays open after an error
+			clickDialogCancelButton(ProviderSection.DISCIPLINARY_ACTIONS);
+		} else {
+			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		}
 		return msgDisplay;
 	}
 
@@ -617,6 +640,150 @@ public class UpdateProviderPage extends ViewProviderPage {
 	}
 
 	/**
+	 * Cease Last Data Block - ceases the last active data block in the section
+	 *
+	 * @param section the provider section
+	 */
+	public void ceaseLastDataBlock(ProviderSection section) {
+		int count = grabActiveDataBlockCount(section, true);
+		if (count > 0) {
+			ceaseDataBlock(section, count - 1);
+		}
+	}
+
+	/**
+	 * Gets a list of purpose codes currently used for a specific address type.
+	 * Uniqueness rule for addresses is based on Address Type + Purpose Code combination.
+	 *
+	 * @param addressTypeCode the address type code (e.g., "M" for Mailing, "P" for Physical)
+	 * @return list of purpose codes currently in use for that address type (e.g., "BC", "MC", "HC")
+	 */
+	public List<String> getUsedPurposeCodesForAddressType(String addressTypeCode) {
+		List<String> usedCodes = new ArrayList<>();
+		int totalCount = grabDataBlockCount(ProviderSection.ADDRESSES);
+		
+		for (int i = 0; i < totalCount; i++) {
+			// Skip inactive (ceased) blocks
+			if (!grabDataBlockActive(ProviderSection.ADDRESSES, i)) {
+				continue;
+			}
+			
+			LinkedHashMap<String, String> content = grabDataBlockContent(ProviderSection.ADDRESSES, i);
+			String addressType = content.get("Address Type");
+			String purposeValue = content.get("Address Purpose");
+			
+			if (addressType != null && purposeValue != null) {
+				// Extract the code from format "Description (CODE)" -> "CODE"
+				String typeCode = extractCodeFromParens(addressType);
+				// Only add if the address type matches
+				if (typeCode != null && typeCode.equals(addressTypeCode)) {
+					// Extract the purpose code from format "Description (CODE)" -> "CODE"
+					String purposeCode = extractCodeFromParens(purposeValue);
+					if (purposeCode != null) {
+						usedCodes.add(purposeCode);
+					}
+				}
+			}
+		}
+		return usedCodes;
+	}
+
+	/**
+	 * Extracts the code from within parentheses at the end of a string.
+	 * For example: "Ministry Contact (MC)" -> "MC"
+	 *
+	 * @param value the string containing a code in parentheses
+	 * @return the extracted code, or null if not found
+	 */
+	private String extractCodeFromParens(String value) {
+		if (value == null || value.isEmpty()) {
+			return null;
+		}
+		Matcher matcher = CODE_IN_PARENS_PATTERN.matcher(value);
+		if (matcher.find()) {
+			return matcher.group(1);
+		}
+		return null;
+	}
+
+	/**
+	 * Gets a list of purpose codes currently used in a section (for telecoms, electronic addresses)
+	 *
+	 * @param section the provider section
+	 * @return list of purpose codes currently in use (e.g., "BC", "MC", "HC")
+	 */
+	public List<String> getUsedPurposeCodes(ProviderSection section) {
+		List<String> usedCodes = new ArrayList<>();
+		int totalCount = grabDataBlockCount(section);
+		
+		String purposeKey;
+		switch (section) {
+			case TELECOMMUNICATIONS:
+				purposeKey = "Telecom Purpose";
+				break;
+			case ELECTRONIC_ADDRESSES:
+				purposeKey = "Electronic Address Purpose";
+				break;
+			default:
+				return usedCodes;
+		}
+		
+		for (int i = 0; i < totalCount; i++) {
+			// Skip inactive (ceased) blocks
+			if (!grabDataBlockActive(section, i)) {
+				continue;
+			}
+			
+			LinkedHashMap<String, String> content = grabDataBlockContent(section, i);
+			String purposeValue = content.get(purposeKey);
+			if (purposeValue != null && !purposeValue.isEmpty()) {
+				// Extract the code from format "Description (CODE)" -> "CODE"
+				String code = extractCodeFromParens(purposeValue);
+				if (code != null) {
+					usedCodes.add(code);
+				}
+			}
+		}
+		return usedCodes;
+	}
+
+	/**
+	 * Gets an available telecommunication purpose code that is not currently used for the given address type.
+	 * Since uniqueness is based on Address Type + Purpose Code, a purpose code can be reused
+	 * if it's only used by a different address type.
+	 *
+	 * @param addressTypeCode the address type code (e.g., "M" for Mailing, "P" for Physical)
+	 * @return the text of an available TelecommunicationPurpose, or null if all are used
+	 */
+	public String getAvailablePurposeCodeForAddressType(String addressTypeCode) {
+		List<String> usedCodes = getUsedPurposeCodesForAddressType(addressTypeCode);
+		
+		for (TelecommunicationPurpose purpose : TelecommunicationPurpose.values()) {
+			if (!usedCodes.contains(purpose.getStartText())) {
+				return purpose.getText();
+			}
+		}
+		return null; // All purpose codes are used for this address type
+	}
+
+	/**
+	 * Gets an available telecommunication purpose code that is not currently used in the section
+	 *
+	 * @param section the provider section (TELECOMMUNICATIONS or ELECTRONIC_ADDRESSES)
+	 * @return the text of an available TelecommunicationPurpose, or null if all are used
+	 */
+	public String getAvailablePurposeCode(ProviderSection section) {
+		List<String> usedCodes = getUsedPurposeCodes(section);
+		
+		for (TelecommunicationPurpose purpose : TelecommunicationPurpose.values()) {
+			if (!usedCodes.contains(purpose.getStartText())) {
+				return purpose.getText();
+			}
+		}
+		return null; // All purpose codes are used
+	}
+
+	/**
 	 * Cease All Data Block Under Section
 	 *
 	 * @param section the provider section
@@ -630,13 +797,21 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 	public void clickDialogCancelButton(ProviderSection providerSection)
 	{
-		String dialogCss = getDialogCss(providerSection);
-
-		WebElement cancelButton = selenium_.findElement(By.linkText("Cancel"));
-		selenium_.scrollIntoView(cancelButton);
-		cancelButton.click();
-
-		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		   String dialogCss = getDialogCss(providerSection);
+		   try {
+			   List<WebElement> cancelButtons = selenium_.findElements(By.linkText("Cancel"));
+			   if (!cancelButtons.isEmpty() && cancelButtons.get(0).isDisplayed()) {
+				   selenium_.scrollIntoView(cancelButtons.get(0));
+				   cancelButtons.get(0).click();
+				   selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+			   } else {
+				   // Cancel button not found or not visible, dialog may already be closed
+				   // Optionally log or handle gracefully
+			   }
+		   } catch (Exception e) {
+			   // Handle exception gracefully, dialog may already be closed
+			   // Optionally log error
+		   }
 	}
 
 	public void cancleAddDisciplinaryActionDataBlock(String actionIdentifier, boolean display, String description, String archiveDate,
@@ -649,9 +824,15 @@ public class UpdateProviderPage extends ViewProviderPage {
 		fillDisciplinaryActionDataBlock(actionIdentifier, display, description, archiveDate, effectiveFrom,
 				effectiveTo);
 
-		WebElement cancelButton = selenium_.findElement(By.linkText("Cancel"));
-		selenium_.scrollIntoView(cancelButton);
-		cancelButton.click();
+		   try {
+			   List<WebElement> cancelButtons = selenium_.findElements(By.linkText("Cancel"));
+			   if (!cancelButtons.isEmpty() && cancelButtons.get(0).isDisplayed()) {
+				   selenium_.scrollIntoView(cancelButtons.get(0));
+				   cancelButtons.get(0).click();
+			   }
+		   } catch (Exception e) {
+			   // Handle exception gracefully
+		   }
 
 		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
 
@@ -710,10 +891,13 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 		clickDialogSubmitButton(ProviderSection.ELECTRONIC_ADDRESSES, expectError);
 
-		if (expectError)
+		if (expectError) {
+			// Wait for error message (waitErrorMessage already clicks Cancel when done)
 			msgDisplay = waitErrorMessage(ProviderSection.ELECTRONIC_ADDRESSES);
-
-		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		} else {
+			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+			clickDialogCancelButton(ProviderSection.ELECTRONIC_ADDRESSES);
+		}
 		return msgDisplay;
 	}
 
@@ -734,9 +918,15 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 		fillElectronicAddressDataBlock(type, purpose, address, effectiveFrom, effectiveTo);
 
-		WebElement cancelButton = selenium_.findElement(By.linkText("Cancel"));
-		selenium_.scrollIntoView(cancelButton);
-		cancelButton.click();
+		   try {
+			   List<WebElement> cancelButtons = selenium_.findElements(By.linkText("Cancel"));
+			   if (!cancelButtons.isEmpty() && cancelButtons.get(0).isDisplayed()) {
+				   selenium_.scrollIntoView(cancelButtons.get(0));
+				   cancelButtons.get(0).click();
+			   }
+		   } catch (Exception e) {
+			   // Handle exception gracefully
+		   }
 
 		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
 	}
@@ -774,10 +964,13 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 		clickDialogSubmitButton(ProviderSection.ELECTRONIC_ADDRESSES, expectError);
 
-		if (expectError)
+		if (expectError) {
+			// Wait for error message (waitErrorMessage already clicks Cancel when done)
 			msgDisplay = waitErrorMessage(ProviderSection.ELECTRONIC_ADDRESSES);
-
-		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		} else {
+			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+			clickDialogCancelButton(ProviderSection.ELECTRONIC_ADDRESSES);
+		}
 		return msgDisplay;
 	}
 
@@ -830,6 +1023,13 @@ public class UpdateProviderPage extends ViewProviderPage {
 		if (!StringUtils.isEmpty(addressLine3))
 			addressLine3Element.sendKeys(addressLine3);
 
+		// Set country dropdown FIRST (this may change province field to text input for non-CA/US)
+		if (!StringUtils.isEmpty(country)) {
+			setDropdownListByVisibleText(ProviderSection.ADDRESSES, "country", country);
+			// Wait for province fragment to update after country change
+			waitSeconds(2);
+		}
+
 		// Fill city (autocomplete input) - type city and click first autocomplete result
 		if (!StringUtils.isEmpty(city)) {
 			String cityInputCss = "input#" + formName + "\\:city_input";
@@ -847,14 +1047,19 @@ public class UpdateProviderPage extends ViewProviderPage {
 			}
 		}
 
-		// Set province dropdown
+		// Set province - check if it's a dropdown (CA/US) or text input (other countries)
 		if (!StringUtils.isEmpty(province)) {
-			setDropdownListByVisibleText(ProviderSection.ADDRESSES, "province_address", province);
-		}
-
-		// Set country dropdown
-		if (!StringUtils.isEmpty(country)) {
-			setDropdownListByVisibleText(ProviderSection.ADDRESSES, "country", country);
+			String provinceTxtCss = dialogCss + " input#" + formName + "\\:province_txt";
+			List<WebElement> provinceTxtElements = selenium_.findElements(By.cssSelector(provinceTxtCss));
+			if (!provinceTxtElements.isEmpty() && provinceTxtElements.get(0).isDisplayed()) {
+				// Province is a text input (non-CA/US country)
+				WebElement provinceTxt = provinceTxtElements.get(0);
+				provinceTxt.clear();
+				provinceTxt.sendKeys(province);
+			} else {
+				// Province is a dropdown (CA/US)
+				setDropdownListByVisibleText(ProviderSection.ADDRESSES, "province_address", province);
+			}
 		}
 
 		// Fill postal code
@@ -897,14 +1102,138 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 		clickDialogSubmitButton(ProviderSection.ADDRESSES, expectError);
 
-		// Handle address validation popups that may appear
-		handleAddressValidationDialog();
-
-		if (expectError)
+		if (expectError) {
+			// Wait for error message (waitErrorMessage already clicks Cancel when done)
 			msgDisplay = waitErrorMessage(ProviderSection.ADDRESSES);
-
-		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		} else {
+			// Handle address validation popups that may appear (only when not expecting error)
+			handleAddressValidationDialog();
+			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		}
 		return msgDisplay;
+	}
+
+	/**
+	 * Attempts to add an address data block with provided values, using raw city input (no autocomplete).
+	 * Use this method when the city value is not expected to appear in autocomplete suggestions
+	 * (e.g., when testing validation with invalid/long city names).
+	 *
+	 * @param addressType   the type of address (e.g., "P - Physical location", "M - Mailing address")
+	 * @param purpose       the purpose of the address (e.g., "MC - Ministry Contact")
+	 * @param addressLine1  the first line of the address
+	 * @param addressLine2  the second line of the address (optional)
+	 * @param addressLine3  the third line of the address (optional)
+	 * @param city          the city name (entered without autocomplete)
+	 * @param province      the province/state code (e.g., "BC - British Columbia")
+	 * @param country       the country code (e.g., "CA - CANADA")
+	 * @param postalCode    the postal code (optional)
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo   the effective to date
+	 * @param expectError   whether an error is expected
+	 * @return the error message if expectError is true, otherwise an empty string
+	 */
+	public String addAddressDataBlockRawCity(String addressType, String purpose, String addressLine1,
+			String addressLine2, String addressLine3, String city, String province, String country,
+			String postalCode, String effectiveFrom, String effectiveTo, boolean expectError) {
+		String msgDisplay = "";
+		String dialogCss = getDialogCss(ProviderSection.ADDRESSES);
+
+		clickHeaderAddButton(ProviderSection.ADDRESSES);
+
+		fillAddressDataBlockRawCity(addressType, purpose, addressLine1, addressLine2, addressLine3,
+				city, province, country, postalCode, effectiveFrom, effectiveTo);
+
+		clickDialogSubmitButton(ProviderSection.ADDRESSES, expectError);
+
+		if (expectError) {
+			// Wait for error message (waitErrorMessage already clicks Cancel when done)
+			msgDisplay = waitErrorMessage(ProviderSection.ADDRESSES);
+		} else {
+			// Handle address validation popups that may appear (only when not expecting error)
+			handleAddressValidationDialog();
+			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		}
+		return msgDisplay;
+	}
+
+	/**
+	 * Fills the address data block form with raw city input (no autocomplete selection).
+	 */
+	private void fillAddressDataBlockRawCity(String addressType, String purpose, String addressLine1,
+			String addressLine2, String addressLine3, String city, String province, String country,
+			String postalCode, String effectiveFrom, String effectiveTo) {
+		String formName = DIALOG_MAP.get(ProviderSection.ADDRESSES).getFormName();
+		String dialogCss = getDialogCss(ProviderSection.ADDRESSES);
+
+		// Wait for dialog to be visible and stable
+		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
+		waitSeconds(2);
+
+		setDropdownListByVisibleText(ProviderSection.ADDRESSES, "addressType", addressType);
+		setDropdownListByVisibleText(ProviderSection.ADDRESSES, "addressPurpose", purpose);
+
+		// Fill address line 1
+		String addressLine1Css = dialogCss + " >input#" + formName + "\\:addressLine1";
+		WebElement addressLine1Element = selenium_.findElement(By.cssSelector(addressLine1Css));
+		addressLine1Element.clear();
+		if (!StringUtils.isEmpty(addressLine1))
+			addressLine1Element.sendKeys(addressLine1);
+
+		// Fill address line 2
+		String addressLine2Css = dialogCss + " >input#" + formName + "\\:addressLine2";
+		WebElement addressLine2Element = selenium_.findElement(By.cssSelector(addressLine2Css));
+		addressLine2Element.clear();
+		if (!StringUtils.isEmpty(addressLine2))
+			addressLine2Element.sendKeys(addressLine2);
+
+		// Fill address line 3
+		String addressLine3Css = dialogCss + " >input#" + formName + "\\:addressLine3";
+		WebElement addressLine3Element = selenium_.findElement(By.cssSelector(addressLine3Css));
+		addressLine3Element.clear();
+		if (!StringUtils.isEmpty(addressLine3))
+			addressLine3Element.sendKeys(addressLine3);
+
+		// Set country dropdown FIRST (this may change province field to text input for non-CA/US)
+		if (!StringUtils.isEmpty(country)) {
+			setDropdownListByVisibleText(ProviderSection.ADDRESSES, "country", country);
+			// Wait for province fragment to update after country change
+			waitSeconds(2);
+		}
+
+		// Fill city (raw input - no autocomplete selection)
+		if (!StringUtils.isEmpty(city)) {
+			String cityInputCss = "input#" + formName + "\\:city_input";
+			WebElement cityInput = selenium_.findElement(By.cssSelector(cityInputCss));
+			cityInput.clear();
+			cityInput.sendKeys(city);
+			// Tab out to avoid autocomplete panel interference
+			cityInput.sendKeys(Keys.TAB);
+			waitSeconds(1);
+		}
+
+		// Set province - check if it's a dropdown (CA/US) or text input (other countries)
+		if (!StringUtils.isEmpty(province)) {
+			String provinceTxtCss = dialogCss + " input#" + formName + "\\:province_txt";
+			List<WebElement> provinceTxtElements = selenium_.findElements(By.cssSelector(provinceTxtCss));
+			if (!provinceTxtElements.isEmpty() && provinceTxtElements.get(0).isDisplayed()) {
+				// Province is a text input (non-CA/US country)
+				WebElement provinceTxt = provinceTxtElements.get(0);
+				provinceTxt.clear();
+				provinceTxt.sendKeys(province);
+			} else {
+				// Province is a dropdown (CA/US)
+				setDropdownListByVisibleText(ProviderSection.ADDRESSES, "province_address", province);
+			}
+		}
+
+		// Fill postal code
+		String postalCodeCss = dialogCss + " >input#" + formName + "\\:postalCode";
+		WebElement postalCodeElement = selenium_.findElement(By.cssSelector(postalCodeCss));
+		postalCodeElement.clear();
+		if (!StringUtils.isEmpty(postalCode))
+			postalCodeElement.sendKeys(postalCode);
+
+		setDialogEffectiveFromAndEffectiveTo(ProviderSection.ADDRESSES, effectiveFrom, effectiveTo);
 	}
 
 	/**
@@ -1021,10 +1350,13 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 		clickDialogSubmitButton(ProviderSection.ADDRESSES, expectError);
 
-		if (expectError)
+		if (expectError) {
 			msgDisplay = waitErrorMessage(ProviderSection.ADDRESSES);
-
-		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+			// Cancel the dialog since it stays open after an error
+			clickDialogCancelButton(ProviderSection.ADDRESSES);
+		} else {
+			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		}
 		return msgDisplay;
 	}
 
@@ -1107,10 +1439,13 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 		clickDialogSubmitButton(ProviderSection.TELECOMMUNICATIONS, expectError);
 
-		if (expectError)
+		if (expectError) {
+			// Wait for error message (waitErrorMessage already clicks Cancel when done)
 			msgDisplay = waitErrorMessage(ProviderSection.TELECOMMUNICATIONS);
-
-		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		} else {
+			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+			clickDialogCancelButton(ProviderSection.TELECOMMUNICATIONS); // Cancel to close the dialog after successful add
+		}
 		return msgDisplay;
 	}
 
@@ -1190,10 +1525,13 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 		clickDialogSubmitButton(ProviderSection.TELECOMMUNICATIONS, expectError);
 
-		if (expectError)
+		if (expectError) {
 			msgDisplay = waitErrorMessage(ProviderSection.TELECOMMUNICATIONS);
-
-		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+			// Cancel the dialog since it stays open after an error
+			clickDialogCancelButton(ProviderSection.TELECOMMUNICATIONS);
+		} else {
+			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		}
 		return msgDisplay;
 	}
 }

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -118,13 +118,17 @@ public class UpdateProviderPage extends ViewProviderPage {
 				// Fall back to any visible button
 			}
 
-			// Generic fallback: first displayed & enabled button
+			try {
+				// Generic fallback: first displayed & enabled button
 			for (WebElement btn : validationWidget.findElements(By.tagName("button"))) {
 				if (btn.isDisplayed() && btn.isEnabled()) {
 					btn.click();
 					waitSeconds(2);
 					return;
 				}
+			}
+			} catch (org.openqa.selenium.NoSuchElementException ignore) {
+				//Generic catch block
 			}
 		}
 	}
@@ -1102,12 +1106,13 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 		clickDialogSubmitButton(ProviderSection.ADDRESSES, expectError);
 
+		// Handle address validation popups that may appear (only when not expecting error)
+		handleAddressValidationDialog();
+
 		if (expectError) {
 			// Wait for error message (waitErrorMessage already clicks Cancel when done)
 			msgDisplay = waitErrorMessage(ProviderSection.ADDRESSES);
 		} else {
-			// Handle address validation popups that may appear (only when not expecting error)
-			handleAddressValidationDialog();
 			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
 		}
 		return msgDisplay;

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -23,27 +23,29 @@ import ca.bc.gov.health.qa.autotest.runner.util.selenium.SeleniumSession;
 
 public class UpdateProviderPage extends ViewProviderPage {
 
-	public static final Map<ProviderSection, ProviderDialog> DIALOG_MAP = Map.of(
-			ProviderSection.REGISTRY_IDENTIFIERS, new ProviderDialog("maintainRegIdDialog", "maintainRegIdForm", "effectiveStartDate",
-					"effectiveEndDate", "registryIdSubmitButton", "EndReasonType","Add"),
-			ProviderSection.IDENTIFIERS, new ProviderDialog("maintainIdDialog", "maintainIdentifierForm", "effectiveFromDate",
-					"effectiveToDate", "idSubmitButton", "EndReasonType","Add"),
-			ProviderSection.ORGANIZATION_NAMES, new ProviderDialog("maintainOrgNameDialog", "maintainOrgNameForm", "effectiveStartDate",
-							"effectiveEndDate", "orgNameSubmitButton", "EndReasonType","Add a new Organizational Name"),
-			ProviderSection.PRACTITIONER_NAMES, new ProviderDialog("maintainPersonNameDialog", "maintainPersonNameForm", "effectiveStartDate",
-					"effectiveEndDate", "personNameSubmitButton", "EndReasonType","Add a new Practitioner Name"),
-			ProviderSection.NOTES, new ProviderDialog("maintainNoteDialog", "maintainNoteForm", "effectiveFromDate",
-					"effectiveToDate", "idNoteSubmitButton", "endReasonCode","Add a new Note"),
-			ProviderSection.ORGANIZATION_RELATIONSHIPS, new ProviderDialog("maintainOrganizationRelationshipDialog", "maintainOrgRelationshipForm", "effectiveStartDate",
-					"effectiveEndDate", "orgRelationshipSubmitButton", "EndReasonType","Add a new Organization Relationship"),
-			ProviderSection.TELECOMMUNICATIONS, new ProviderDialog("maintainTelecomDialog", "maintainTelecomForm", "effectiveFromDate",
-					"effectiveToDate", "idTeleSubmitButton", "EndReasonType","Add a new Telecommunication"),
-			ProviderSection.ELECTRONIC_ADDRESSES, new ProviderDialog("maintainElectronicAddressDialog", "maintainElectronicAddressForm", "effectiveStartDate",
-					"effectiveEndDate", "electronicAddressSubmitButton", "EndReasonType","Add a new Electronic Address"),
-			ProviderSection.CONDITIONS, new ProviderDialog("maintainConditionDialog", "maintainConditionForm", "effectiveFromDate",
-					"effectiveToDate", "idSubmitButton", "EndReasonType","Add a new Condition"),
-			ProviderSection.DISCIPLINARY_ACTIONS, new ProviderDialog("maintainDisActionDialog", "maintainDisActionForm", "effectiveFromDate",
-					"effectiveToDate", "idSubmitButton", "EndReasonType","Add a new Disciplinary Action")
+	public static final Map<ProviderSection, ProviderDialog> DIALOG_MAP = Map.ofEntries(
+			Map.entry(ProviderSection.REGISTRY_IDENTIFIERS, new ProviderDialog("maintainRegIdDialog", "maintainRegIdForm", "effectiveStartDate",
+					"effectiveEndDate", "registryIdSubmitButton", "EndReasonType","Add")),
+			Map.entry(ProviderSection.IDENTIFIERS, new ProviderDialog("maintainIdDialog", "maintainIdentifierForm", "effectiveFromDate",
+					"effectiveToDate", "idSubmitButton", "EndReasonType","Add")),
+			Map.entry(ProviderSection.ORGANIZATION_NAMES, new ProviderDialog("maintainOrgNameDialog", "maintainOrgNameForm", "effectiveStartDate",
+							"effectiveEndDate", "orgNameSubmitButton", "EndReasonType","Add a new Organizational Name")),
+			Map.entry(ProviderSection.PRACTITIONER_NAMES, new ProviderDialog("maintainPersonNameDialog", "maintainPersonNameForm", "effectiveStartDate",
+					"effectiveEndDate", "personNameSubmitButton", "EndReasonType","Add a new Practitioner Name")),
+			Map.entry(ProviderSection.NOTES, new ProviderDialog("maintainNoteDialog", "maintainNoteForm", "effectiveFromDate",
+					"effectiveToDate", "idNoteSubmitButton", "endReasonCode","Add a new Note")),
+			Map.entry(ProviderSection.ORGANIZATION_RELATIONSHIPS, new ProviderDialog("maintainOrganizationRelationshipDialog", "maintainOrgRelationshipForm", "effectiveStartDate",
+					"effectiveEndDate", "orgRelationshipSubmitButton", "EndReasonType","Add a new Organization Relationship")),
+			Map.entry(ProviderSection.TELECOMMUNICATIONS, new ProviderDialog("maintainTelecomDialog", "maintainTelecomForm", "effectiveFromDate",
+					"effectiveToDate", "idTeleSubmitButton", "EndReasonType","Add a new Telecommunication")),
+			Map.entry(ProviderSection.ELECTRONIC_ADDRESSES, new ProviderDialog("maintainElectronicAddressDialog", "maintainElectronicAddressForm", "effectiveStartDate",
+					"effectiveEndDate", "electronicAddressSubmitButton", "EndReasonType","Add a new Electronic Address")),
+			Map.entry(ProviderSection.CONDITIONS, new ProviderDialog("maintainConditionDialog", "maintainConditionForm", "effectiveFromDate",
+					"effectiveToDate", "idSubmitButton", "EndReasonType","Add a new Condition")),
+			Map.entry(ProviderSection.DISCIPLINARY_ACTIONS, new ProviderDialog("maintainDisActionDialog", "maintainDisActionForm", "effectiveFromDate",
+					"effectiveToDate", "idSubmitButton", "EndReasonType","Add a new Disciplinary Action")),
+			Map.entry(ProviderSection.ADDRESSES, new ProviderDialog("maintainAddressDialog", "maintainAddressForm", "effectiveFromDate",
+					"effectiveToDate", "idAddressSubmitButton", "EndReasonType","Add a new Address"))
 			);
 
 	public UpdateProviderPage(SeleniumSession selenium, URI uri) {
@@ -584,5 +586,359 @@ public class UpdateProviderPage extends ViewProviderPage {
 		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
 
 		
+	}
+
+	/**
+	 * Fill the Electronic Address Data Block form fields
+	 *
+	 * @param type          the type of electronic address (e.g., "E - Email", "F - FTP", "H - HTTP")
+	 * @param purpose       the purpose of electronic address (e.g., "MC - Ministry Contact")
+	 * @param address       the electronic address value
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo   the effective to date
+	 */
+	private void fillElectronicAddressDataBlock(String type, String purpose, String address,
+			String effectiveFrom, String effectiveTo) {
+		String formName = DIALOG_MAP.get(ProviderSection.ELECTRONIC_ADDRESSES).getFormName();
+		String dialogCss = getDialogCss(ProviderSection.ELECTRONIC_ADDRESSES);
+
+		// Wait for dialog to be visible and stable
+		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
+		waitSeconds(2);
+
+		setDropdownListByVisibleText(ProviderSection.ELECTRONIC_ADDRESSES, "type", type);
+		setDropdownListByVisibleText(ProviderSection.ELECTRONIC_ADDRESSES, "purpose", purpose);
+
+		String inputAddressCss = dialogCss + " >input#" + formName + "\\:electronicAddress";
+		WebElement inputAddress = selenium_.findElement(By.cssSelector(inputAddressCss));
+		inputAddress.clear();
+		if (!StringUtils.isEmpty(address))
+			inputAddress.sendKeys(address);
+
+		setDialogEffectiveFromAndEffectiveTo(ProviderSection.ELECTRONIC_ADDRESSES, effectiveFrom, effectiveTo);
+	}
+
+	/**
+	 * Attempts to add an electronic address data block with provided values
+	 *
+	 * @param type          the type of electronic address (e.g., "E - Email", "F - FTP", "H - HTTP")
+	 * @param purpose       the purpose of electronic address (e.g., "MC - Ministry Contact")
+	 * @param address       the electronic address value
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo   the effective to date
+	 * @param expectError   whether an error is expected
+	 * @return the error message if expectError is true, otherwise an empty string
+	 */
+	public String addElectronicAddressDataBlock(String type, String purpose, String address,
+			String effectiveFrom, String effectiveTo, boolean expectError) {
+		String msgDisplay = "";
+		String dialogCss = getDialogCss(ProviderSection.ELECTRONIC_ADDRESSES);
+
+		clickHeaderAddButton(ProviderSection.ELECTRONIC_ADDRESSES);
+
+		fillElectronicAddressDataBlock(type, purpose, address, effectiveFrom, effectiveTo);
+
+		clickDialogSubmitButton(ProviderSection.ELECTRONIC_ADDRESSES, expectError);
+
+		if (expectError)
+			msgDisplay = waitErrorMessage(ProviderSection.ELECTRONIC_ADDRESSES);
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return msgDisplay;
+	}
+
+	/**
+	 * Cancel adding an electronic address data block after filling the form
+	 *
+	 * @param type          the type of electronic address
+	 * @param purpose       the purpose of electronic address
+	 * @param address       the electronic address value
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo   the effective to date
+	 */
+	public void cancelAddElectronicAddressDataBlock(String type, String purpose, String address,
+			String effectiveFrom, String effectiveTo) {
+		String dialogCss = getDialogCss(ProviderSection.ELECTRONIC_ADDRESSES);
+
+		clickHeaderAddButton(ProviderSection.ELECTRONIC_ADDRESSES);
+
+		fillElectronicAddressDataBlock(type, purpose, address, effectiveFrom, effectiveTo);
+
+		WebElement cancelButton = selenium_.findElement(By.linkText("Cancel"));
+		selenium_.scrollIntoView(cancelButton);
+		cancelButton.click();
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+	}
+
+	/**
+	 * Attempts to update an electronic address data block with provided values
+	 *
+	 * @param address       the electronic address value to update
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo   the effective to date
+	 * @param endReasonCode the end reason code
+	 * @param index         the data block index to update
+	 * @param expectError   whether an error is expected
+	 * @return the error message if expectError is true, otherwise an empty string
+	 */
+	public String updateElectronicAddressDataBlock(String address, String effectiveFrom, String effectiveTo,
+			EndReason endReasonCode, int index, boolean expectError) {
+		String msgDisplay = "";
+		String formName = DIALOG_MAP.get(ProviderSection.ELECTRONIC_ADDRESSES).getFormName();
+		String dialogCss = getDialogCss(ProviderSection.ELECTRONIC_ADDRESSES);
+
+		clickDataBlockUpdateButton(ProviderSection.ELECTRONIC_ADDRESSES, index);
+		waitSeconds(2);
+
+		String inputAddressCss = dialogCss + " >input#" + formName + "\\:electronicAddress";
+		WebElement inputAddress = selenium_.findElement(By.cssSelector(inputAddressCss));
+		inputAddress.clear();
+		if (!StringUtils.isEmpty(address))
+			inputAddress.sendKeys(address);
+
+		if (endReasonCode != null)
+			setEndReasonByVisibleText(ProviderSection.ELECTRONIC_ADDRESSES, endReasonCode.getText());
+
+		setDialogEffectiveFromAndEffectiveTo(ProviderSection.ELECTRONIC_ADDRESSES, effectiveFrom, effectiveTo);
+
+		clickDialogSubmitButton(ProviderSection.ELECTRONIC_ADDRESSES, expectError);
+
+		if (expectError)
+			msgDisplay = waitErrorMessage(ProviderSection.ELECTRONIC_ADDRESSES);
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return msgDisplay;
+	}
+
+	/**
+	 * Fill the Address Data Block form fields
+	 *
+	 * @param addressType   the type of address (e.g., "P - Physical location", "M - Mailing address")
+	 * @param purpose       the purpose of the address (e.g., "MC - Ministry Contact")
+	 * @param addressLine1  the first line of the address
+	 * @param addressLine2  the second line of the address (optional)
+	 * @param addressLine3  the third line of the address (optional)
+	 * @param city          the city name
+	 * @param province      the province/state code (e.g., "BC - British Columbia")
+	 * @param country       the country code (e.g., "CA - CANADA")
+	 * @param postalCode    the postal code (optional)
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo   the effective to date
+	 */
+	private void fillAddressDataBlock(String addressType, String purpose, String addressLine1,
+			String addressLine2, String addressLine3, String city, String province, String country,
+			String postalCode, String effectiveFrom, String effectiveTo) {
+		String formName = DIALOG_MAP.get(ProviderSection.ADDRESSES).getFormName();
+		String dialogCss = getDialogCss(ProviderSection.ADDRESSES);
+
+		// Wait for dialog to be visible and stable
+		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
+		waitSeconds(2);
+
+		setDropdownListByVisibleText(ProviderSection.ADDRESSES, "addressType", addressType);
+		setDropdownListByVisibleText(ProviderSection.ADDRESSES, "addressPurpose", purpose);
+
+		// Fill address line 1
+		String addressLine1Css = dialogCss + " >input#" + formName + "\\:addressLine1";
+		WebElement addressLine1Element = selenium_.findElement(By.cssSelector(addressLine1Css));
+		addressLine1Element.clear();
+		if (!StringUtils.isEmpty(addressLine1))
+			addressLine1Element.sendKeys(addressLine1);
+
+		// Fill address line 2
+		String addressLine2Css = dialogCss + " >input#" + formName + "\\:addressLine2";
+		WebElement addressLine2Element = selenium_.findElement(By.cssSelector(addressLine2Css));
+		addressLine2Element.clear();
+		if (!StringUtils.isEmpty(addressLine2))
+			addressLine2Element.sendKeys(addressLine2);
+
+		// Fill address line 3
+		String addressLine3Css = dialogCss + " >input#" + formName + "\\:addressLine3";
+		WebElement addressLine3Element = selenium_.findElement(By.cssSelector(addressLine3Css));
+		addressLine3Element.clear();
+		if (!StringUtils.isEmpty(addressLine3))
+			addressLine3Element.sendKeys(addressLine3);
+
+		// Fill city (autocomplete input)
+		String cityCss = dialogCss + " span#" + formName + "\\:city >input#" + formName + "\\:city_input";
+		WebElement cityElement = selenium_.findElement(By.cssSelector(cityCss));
+		cityElement.clear();
+		if (!StringUtils.isEmpty(city))
+			cityElement.sendKeys(city);
+
+		// Set province dropdown
+		if (!StringUtils.isEmpty(province)) {
+			setDropdownListByVisibleText(ProviderSection.ADDRESSES, "province_address", province);
+		}
+
+		// Set country dropdown
+		if (!StringUtils.isEmpty(country)) {
+			setDropdownListByVisibleText(ProviderSection.ADDRESSES, "country", country);
+		}
+
+		// Fill postal code
+		String postalCodeCss = dialogCss + " >input#" + formName + "\\:postalCode";
+		WebElement postalCodeElement = selenium_.findElement(By.cssSelector(postalCodeCss));
+		postalCodeElement.clear();
+		if (!StringUtils.isEmpty(postalCode))
+			postalCodeElement.sendKeys(postalCode);
+
+		setDialogEffectiveFromAndEffectiveTo(ProviderSection.ADDRESSES, effectiveFrom, effectiveTo);
+	}
+
+	/**
+	 * Attempts to add an address data block with provided values
+	 *
+	 * @param addressType   the type of address (e.g., "P - Physical location", "M - Mailing address")
+	 * @param purpose       the purpose of the address (e.g., "MC - Ministry Contact")
+	 * @param addressLine1  the first line of the address
+	 * @param addressLine2  the second line of the address (optional)
+	 * @param addressLine3  the third line of the address (optional)
+	 * @param city          the city name
+	 * @param province      the province/state code (e.g., "BC - British Columbia")
+	 * @param country       the country code (e.g., "CA - CANADA")
+	 * @param postalCode    the postal code (optional)
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo   the effective to date
+	 * @param expectError   whether an error is expected
+	 * @return the error message if expectError is true, otherwise an empty string
+	 */
+	public String addAddressDataBlock(String addressType, String purpose, String addressLine1,
+			String addressLine2, String addressLine3, String city, String province, String country,
+			String postalCode, String effectiveFrom, String effectiveTo, boolean expectError) {
+		String msgDisplay = "";
+		String dialogCss = getDialogCss(ProviderSection.ADDRESSES);
+
+		clickHeaderAddButton(ProviderSection.ADDRESSES);
+
+		fillAddressDataBlock(addressType, purpose, addressLine1, addressLine2, addressLine3,
+				city, province, country, postalCode, effectiveFrom, effectiveTo);
+
+		clickDialogSubmitButton(ProviderSection.ADDRESSES, expectError);
+
+		if (expectError)
+			msgDisplay = waitErrorMessage(ProviderSection.ADDRESSES);
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return msgDisplay;
+	}
+
+	/**
+	 * Cancel adding an address data block after filling the form
+	 *
+	 * @param addressType   the type of address
+	 * @param purpose       the purpose of the address
+	 * @param addressLine1  the first line of the address
+	 * @param addressLine2  the second line of the address (optional)
+	 * @param addressLine3  the third line of the address (optional)
+	 * @param city          the city name
+	 * @param province      the province/state code
+	 * @param country       the country code
+	 * @param postalCode    the postal code (optional)
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo   the effective to date
+	 */
+	public void cancelAddAddressDataBlock(String addressType, String purpose, String addressLine1,
+			String addressLine2, String addressLine3, String city, String province, String country,
+			String postalCode, String effectiveFrom, String effectiveTo) {
+		String dialogCss = getDialogCss(ProviderSection.ADDRESSES);
+
+		clickHeaderAddButton(ProviderSection.ADDRESSES);
+
+		fillAddressDataBlock(addressType, purpose, addressLine1, addressLine2, addressLine3,
+				city, province, country, postalCode, effectiveFrom, effectiveTo);
+
+		WebElement cancelButton = selenium_.findElement(By.linkText("Cancel"));
+		selenium_.scrollIntoView(cancelButton);
+		cancelButton.click();
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+	}
+
+	/**
+	 * Attempts to update an address data block with provided values
+	 *
+	 * @param addressLine1  the first line of the address
+	 * @param addressLine2  the second line of the address (optional)
+	 * @param addressLine3  the third line of the address (optional)
+	 * @param city          the city name
+	 * @param province      the province/state code
+	 * @param country       the country code
+	 * @param postalCode    the postal code (optional)
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo   the effective to date
+	 * @param endReasonCode the end reason code
+	 * @param index         the data block index to update
+	 * @param expectError   whether an error is expected
+	 * @return the error message if expectError is true, otherwise an empty string
+	 */
+	public String updateAddressDataBlock(String addressLine1, String addressLine2, String addressLine3,
+			String city, String province, String country, String postalCode,
+			String effectiveFrom, String effectiveTo, EndReason endReasonCode, int index, boolean expectError) {
+		String msgDisplay = "";
+		String formName = DIALOG_MAP.get(ProviderSection.ADDRESSES).getFormName();
+		String dialogCss = getDialogCss(ProviderSection.ADDRESSES);
+
+		clickDataBlockUpdateButton(ProviderSection.ADDRESSES, index);
+		waitSeconds(2);
+
+		// Update address line 1
+		String addressLine1Css = dialogCss + " >input#" + formName + "\\:addressLine1";
+		WebElement addressLine1Element = selenium_.findElement(By.cssSelector(addressLine1Css));
+		addressLine1Element.clear();
+		if (!StringUtils.isEmpty(addressLine1))
+			addressLine1Element.sendKeys(addressLine1);
+
+		// Update address line 2
+		String addressLine2Css = dialogCss + " >input#" + formName + "\\:addressLine2";
+		WebElement addressLine2Element = selenium_.findElement(By.cssSelector(addressLine2Css));
+		addressLine2Element.clear();
+		if (!StringUtils.isEmpty(addressLine2))
+			addressLine2Element.sendKeys(addressLine2);
+
+		// Update address line 3
+		String addressLine3Css = dialogCss + " >input#" + formName + "\\:addressLine3";
+		WebElement addressLine3Element = selenium_.findElement(By.cssSelector(addressLine3Css));
+		addressLine3Element.clear();
+		if (!StringUtils.isEmpty(addressLine3))
+			addressLine3Element.sendKeys(addressLine3);
+
+		// Update city
+		String cityCss = dialogCss + " span#" + formName + "\\:city >input#" + formName + "\\:city_input";
+		WebElement cityElement = selenium_.findElement(By.cssSelector(cityCss));
+		cityElement.clear();
+		if (!StringUtils.isEmpty(city))
+			cityElement.sendKeys(city);
+
+		// Update province
+		if (!StringUtils.isEmpty(province)) {
+			setDropdownListByVisibleText(ProviderSection.ADDRESSES, "province_address", province);
+		}
+
+		// Update country
+		if (!StringUtils.isEmpty(country)) {
+			setDropdownListByVisibleText(ProviderSection.ADDRESSES, "country", country);
+		}
+
+		// Update postal code
+		String postalCodeCss = dialogCss + " >input#" + formName + "\\:postalCode";
+		WebElement postalCodeElement = selenium_.findElement(By.cssSelector(postalCodeCss));
+		postalCodeElement.clear();
+		if (!StringUtils.isEmpty(postalCode))
+			postalCodeElement.sendKeys(postalCode);
+
+		if (endReasonCode != null)
+			setEndReasonByVisibleText(ProviderSection.ADDRESSES, endReasonCode.getText());
+
+		setDialogEffectiveFromAndEffectiveTo(ProviderSection.ADDRESSES, effectiveFrom, effectiveTo);
+
+		clickDialogSubmitButton(ProviderSection.ADDRESSES, expectError);
+
+		if (expectError)
+			msgDisplay = waitErrorMessage(ProviderSection.ADDRESSES);
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return msgDisplay;
 	}
 }

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -16,6 +16,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import ca.bc.gov.health.qa.autotest.core.util.net.UriUtils;
+import ca.bc.gov.health.qa.autotest.plr.web.pages.components.AutocompleteMenu;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.components.DropDownMenu;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.EndReason;
 import ca.bc.gov.health.qa.autotest.runner.util.selenium.SeleniumExpectedConditions;
@@ -50,6 +51,73 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 	public UpdateProviderPage(SeleniumSession selenium, URI uri) {
 		super(selenium, uri);
+	}
+
+	private static final String WIDGET_TITLE_SPAN_CSS = "div.ui-dialog-titlebar > span.ui-dialog-title";
+
+	/**
+	 * Finds a visible dialog widget by its title prefix
+	 *
+	 * @param widgetTitlePrefix a string of characters to find in the widget title
+	 * @return a WebElement of a widget matching the prefix, or null if not found
+	 */
+	private WebElement findVisibleWidget(String widgetTitlePrefix) {
+		for (WebElement elem : selenium_.findElements(By.cssSelector("div[role='dialog']"))) {
+			String title;
+			try {
+				title = elem.findElement(By.cssSelector(WIDGET_TITLE_SPAN_CSS)).getAttribute("innerHTML");
+			} catch (org.openqa.selenium.NoSuchElementException ignore) {
+				continue;
+			}
+			if (title == null || title.isEmpty()) continue;
+			if (!title.contains(widgetTitlePrefix)) continue;
+			// Skip hidden/inactive dialogs
+			String ariaHidden = elem.getAttribute("aria-hidden");
+			if ("true".equals(ariaHidden) || !elem.isDisplayed()) continue;
+			return elem;
+		}
+		return null;
+	}
+
+	/**
+	 * Handles address validation dialogs that may appear after submitting an address.
+	 * Clicks "Continue w/ Original" button if a validation dialog is displayed.
+	 */
+	public void handleAddressValidationDialog() {
+		waitSeconds(2); // Give UI time to render any validation dialogs
+
+		// Try different dialog title prefixes that may appear
+		String[] dialogTitles = {"Address Invalid", "Address Recommended", "Validation", "Address Provided"};
+		WebElement validationWidget = null;
+
+		for (String title : dialogTitles) {
+			validationWidget = findVisibleWidget(title);
+			if (validationWidget != null) break;
+		}
+
+		if (validationWidget != null) {
+			// Look for "Continue w/ Original" button first, then fall back to any button
+			try {
+				WebElement continueBtn = validationWidget.findElement(
+						By.xpath(".//button[contains(.,\"Continue w/ Original\")]"));
+				if (continueBtn.isDisplayed() && continueBtn.isEnabled()) {
+					continueBtn.click();
+					waitSeconds(2);
+					return;
+				}
+			} catch (org.openqa.selenium.NoSuchElementException ignore) {
+				// Fall back to any visible button
+			}
+
+			// Generic fallback: first displayed & enabled button
+			for (WebElement btn : validationWidget.findElements(By.tagName("button"))) {
+				if (btn.isDisplayed() && btn.isEnabled()) {
+					btn.click();
+					waitSeconds(2);
+					return;
+				}
+			}
+		}
 	}
 
 	/**
@@ -282,7 +350,8 @@ public class UpdateProviderPage extends ViewProviderPage {
 		String submitButtonName = DIALOG_MAP.get(section).getSubmitButtonName();
 		String dialogCss = getDialogCss(section);
 
-		String buttonCss = dialogCss + " > div.formControls" + " > button#" + formName + "\\:" + submitButtonName;
+		// Use descendant selector (space) instead of direct child (>) to handle nested div structures
+		String buttonCss = dialogCss + " div.formControls" + " button#" + formName + "\\:" + submitButtonName;
 		WebElement button = selenium_.findElement(By.cssSelector(buttonCss));
 		button.click();
 		waitSeconds(2);
@@ -540,7 +609,8 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 		setEndReasonByVisibleText(section, EndReason.CEASE.getText());
 
-		String buttonCss = dialogCss + " > div.formControls" + " > button#" + formName + "\\:" + submitButtonName;
+		// Use descendant selector (space) instead of direct child (>) to handle nested div structures
+		String buttonCss = dialogCss + " div.formControls" + " button#" + formName + "\\:" + submitButtonName;
 		WebElement button = selenium_.findElement(By.cssSelector(buttonCss));
 		button.click();
 		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
@@ -760,12 +830,22 @@ public class UpdateProviderPage extends ViewProviderPage {
 		if (!StringUtils.isEmpty(addressLine3))
 			addressLine3Element.sendKeys(addressLine3);
 
-		// Fill city (autocomplete input)
-		String cityCss = dialogCss + " span#" + formName + "\\:city >input#" + formName + "\\:city_input";
-		WebElement cityElement = selenium_.findElement(By.cssSelector(cityCss));
-		cityElement.clear();
-		if (!StringUtils.isEmpty(city))
-			cityElement.sendKeys(city);
+		// Fill city (autocomplete input) - type city and click first autocomplete result
+		if (!StringUtils.isEmpty(city)) {
+			String cityInputCss = "input#" + formName + "\\:city_input";
+			String cityPanelCss = "span#" + formName + "\\:city_panel";
+			WebElement cityInput = selenium_.findElement(By.cssSelector(cityInputCss));
+			cityInput.clear();
+			cityInput.sendKeys(city);
+			// Wait for autocomplete panel to appear and click first item
+			selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(cityPanelCss)));
+			waitSeconds(1);
+			List<WebElement> cityItems = selenium_.findElements(By.cssSelector(cityPanelCss + " li.ui-autocomplete-item"));
+			if (!cityItems.isEmpty()) {
+				cityItems.get(0).click();
+				selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(cityPanelCss)));
+			}
+		}
 
 		// Set province dropdown
 		if (!StringUtils.isEmpty(province)) {
@@ -816,6 +896,9 @@ public class UpdateProviderPage extends ViewProviderPage {
 				city, province, country, postalCode, effectiveFrom, effectiveTo);
 
 		clickDialogSubmitButton(ProviderSection.ADDRESSES, expectError);
+
+		// Handle address validation popups that may appear
+		handleAddressValidationDialog();
 
 		if (expectError)
 			msgDisplay = waitErrorMessage(ProviderSection.ADDRESSES);
@@ -904,12 +987,15 @@ public class UpdateProviderPage extends ViewProviderPage {
 		if (!StringUtils.isEmpty(addressLine3))
 			addressLine3Element.sendKeys(addressLine3);
 
-		// Update city
-		String cityCss = dialogCss + " span#" + formName + "\\:city >input#" + formName + "\\:city_input";
-		WebElement cityElement = selenium_.findElement(By.cssSelector(cityCss));
-		cityElement.clear();
-		if (!StringUtils.isEmpty(city))
-			cityElement.sendKeys(city);
+		// Update city (autocomplete input)
+		if (!StringUtils.isEmpty(city)) {
+			AutocompleteMenu cityMenu = new AutocompleteMenu(
+					selenium_,
+					By.cssSelector("input#" + formName + "\\:city_input"),
+					By.cssSelector("span#" + formName + "\\:city_panel")
+			);
+			cityMenu.fillItem(city, null);
+		}
 
 		// Update province
 		if (!StringUtils.isEmpty(province)) {

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -941,4 +941,173 @@ public class UpdateProviderPage extends ViewProviderPage {
 		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
 		return msgDisplay;
 	}
+
+	/**
+	 * Fill the Telecommunication Data Block form fields
+	 *
+	 * @param telecomType   the type of telecommunication (e.g., "T - Telephone", "MB - Mobile")
+	 * @param purpose       the purpose of telecommunication (e.g., "MC - Ministry Contact")
+	 * @param areaCode      the area code
+	 * @param phoneNumber   the phone number
+	 * @param extension     the extension (optional)
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo   the effective to date
+	 */
+	private void fillTelecommunicationDataBlock(String telecomType, String purpose, String areaCode,
+			String phoneNumber, String extension, String effectiveFrom, String effectiveTo) {
+		String formName = DIALOG_MAP.get(ProviderSection.TELECOMMUNICATIONS).getFormName();
+		String dialogCss = getDialogCss(ProviderSection.TELECOMMUNICATIONS);
+
+		// Wait for dialog to be visible and stable
+		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
+		waitSeconds(2);
+
+		setDropdownListByVisibleText(ProviderSection.TELECOMMUNICATIONS, "telecomType", telecomType);
+		waitSeconds(1); // Wait for AJAX update after dropdown selection
+
+		// Organizations use "telecomPurposeFiltered", practitioners use "telecomPurpose"
+		String purposePanelCss = "div#" + formName + "\\:telecomPurposeFiltered_panel";
+		if (!selenium_.findElements(By.cssSelector(purposePanelCss)).isEmpty()) {
+			setDropdownListByVisibleText(ProviderSection.TELECOMMUNICATIONS, "telecomPurposeFiltered", purpose);
+		} else {
+			setDropdownListByVisibleText(ProviderSection.TELECOMMUNICATIONS, "telecomPurpose", purpose);
+		}
+
+		// Fill area code
+		String areaCodeCss = dialogCss + " >input#" + formName + "\\:AreaCode";
+		WebElement areaCodeElement = selenium_.findElement(By.cssSelector(areaCodeCss));
+		areaCodeElement.clear();
+		if (!StringUtils.isEmpty(areaCode))
+			areaCodeElement.sendKeys(areaCode);
+
+		// Fill phone number
+		String phoneNumberCss = dialogCss + " >input#" + formName + "\\:Phone_Number";
+		WebElement phoneNumberElement = selenium_.findElement(By.cssSelector(phoneNumberCss));
+		phoneNumberElement.clear();
+		if (!StringUtils.isEmpty(phoneNumber))
+			phoneNumberElement.sendKeys(phoneNumber);
+
+		// Fill extension
+		String extensionCss = dialogCss + " >input#" + formName + "\\:extension";
+		WebElement extensionElement = selenium_.findElement(By.cssSelector(extensionCss));
+		extensionElement.clear();
+		if (!StringUtils.isEmpty(extension))
+			extensionElement.sendKeys(extension);
+
+		setDialogEffectiveFromAndEffectiveTo(ProviderSection.TELECOMMUNICATIONS, effectiveFrom, effectiveTo);
+	}
+
+	/**
+	 * Attempts to add a telecommunication data block with provided values
+	 *
+	 * @param telecomType   the type of telecommunication (e.g., "T - Telephone", "MB - Mobile")
+	 * @param purpose       the purpose of telecommunication (e.g., "MC - Ministry Contact")
+	 * @param areaCode      the area code
+	 * @param phoneNumber   the phone number
+	 * @param extension     the extension (optional)
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo   the effective to date
+	 * @param expectError   whether an error is expected
+	 * @return the error message if expectError is true, otherwise an empty string
+	 */
+	public String addTelecommunicationDataBlock(String telecomType, String purpose, String areaCode,
+			String phoneNumber, String extension, String effectiveFrom, String effectiveTo, boolean expectError) {
+		String msgDisplay = "";
+		String dialogCss = getDialogCss(ProviderSection.TELECOMMUNICATIONS);
+
+		clickHeaderAddButton(ProviderSection.TELECOMMUNICATIONS);
+
+		fillTelecommunicationDataBlock(telecomType, purpose, areaCode, phoneNumber, extension, effectiveFrom, effectiveTo);
+
+		clickDialogSubmitButton(ProviderSection.TELECOMMUNICATIONS, expectError);
+
+		if (expectError)
+			msgDisplay = waitErrorMessage(ProviderSection.TELECOMMUNICATIONS);
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return msgDisplay;
+	}
+
+	/**
+	 * Cancel adding a telecommunication data block after filling the form
+	 *
+	 * @param telecomType   the type of telecommunication
+	 * @param purpose       the purpose of telecommunication
+	 * @param areaCode      the area code
+	 * @param phoneNumber   the phone number
+	 * @param extension     the extension (optional)
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo   the effective to date
+	 */
+	public void cancelAddTelecommunicationDataBlock(String telecomType, String purpose, String areaCode,
+			String phoneNumber, String extension, String effectiveFrom, String effectiveTo) {
+		String dialogCss = getDialogCss(ProviderSection.TELECOMMUNICATIONS);
+
+		clickHeaderAddButton(ProviderSection.TELECOMMUNICATIONS);
+
+		fillTelecommunicationDataBlock(telecomType, purpose, areaCode, phoneNumber, extension, effectiveFrom, effectiveTo);
+
+		WebElement cancelButton = selenium_.findElement(By.linkText("Cancel"));
+		selenium_.scrollIntoView(cancelButton);
+		cancelButton.click();
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+	}
+
+	/**
+	 * Attempts to update a telecommunication data block with provided values
+	 *
+	 * @param areaCode      the area code
+	 * @param phoneNumber   the phone number
+	 * @param extension     the extension (optional)
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo   the effective to date
+	 * @param endReasonCode the end reason code
+	 * @param index         the data block index to update
+	 * @param expectError   whether an error is expected
+	 * @return the error message if expectError is true, otherwise an empty string
+	 */
+	public String updateTelecommunicationDataBlock(String areaCode, String phoneNumber, String extension,
+			String effectiveFrom, String effectiveTo, EndReason endReasonCode, int index, boolean expectError) {
+		String msgDisplay = "";
+		String formName = DIALOG_MAP.get(ProviderSection.TELECOMMUNICATIONS).getFormName();
+		String dialogCss = getDialogCss(ProviderSection.TELECOMMUNICATIONS);
+
+		clickDataBlockUpdateButton(ProviderSection.TELECOMMUNICATIONS, index);
+		waitSeconds(2);
+
+		// Update area code
+		String areaCodeCss = dialogCss + " >input#" + formName + "\\:AreaCode";
+		WebElement areaCodeElement = selenium_.findElement(By.cssSelector(areaCodeCss));
+		areaCodeElement.clear();
+		if (!StringUtils.isEmpty(areaCode))
+			areaCodeElement.sendKeys(areaCode);
+
+		// Update phone number
+		String phoneNumberCss = dialogCss + " >input#" + formName + "\\:Phone_Number";
+		WebElement phoneNumberElement = selenium_.findElement(By.cssSelector(phoneNumberCss));
+		phoneNumberElement.clear();
+		if (!StringUtils.isEmpty(phoneNumber))
+			phoneNumberElement.sendKeys(phoneNumber);
+
+		// Update extension
+		String extensionCss = dialogCss + " >input#" + formName + "\\:extension";
+		WebElement extensionElement = selenium_.findElement(By.cssSelector(extensionCss));
+		extensionElement.clear();
+		if (!StringUtils.isEmpty(extension))
+			extensionElement.sendKeys(extension);
+
+		if (endReasonCode != null)
+			setEndReasonByVisibleText(ProviderSection.TELECOMMUNICATIONS, endReasonCode.getText());
+
+		setDialogEffectiveFromAndEffectiveTo(ProviderSection.TELECOMMUNICATIONS, effectiveFrom, effectiveTo);
+
+		clickDialogSubmitButton(ProviderSection.TELECOMMUNICATIONS, expectError);
+
+		if (expectError)
+			msgDisplay = waitErrorMessage(ProviderSection.TELECOMMUNICATIONS);
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return msgDisplay;
+	}
 }

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.fail;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -17,12 +18,7 @@ import ca.bc.gov.health.qa.autotest.plr.web.tests.helper.UpdateSimpleHelper;
 import ca.bc.gov.health.qa.autotest.runner.util.log.ExecutionLogManager;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
-import org.openqa.selenium.By;
-import org.openqa.selenium.ElementClickInterceptedException;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.Keys;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.WebElement;
+import org.openqa.selenium.*;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import ca.bc.gov.health.qa.autotest.core.util.net.UriUtils;
@@ -93,9 +89,16 @@ public class UpdateProviderPage extends ViewProviderPage {
 			}
 			if (title == null || title.isEmpty()) continue;
 			if (!title.contains(widgetTitlePrefix)) continue;
+
+			// regrab element (likely to have become stale) and check visibility
+			selenium_.setWaitTimeout(Duration.ofSeconds(10));
+			elem = selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.xpath(
+					"//div[@role='dialog' and @aria-hidden='false' and .//span[contains(text(),'\" + title + \"')]]")));
+			selenium_.setWaitTimeout(Duration.ofSeconds(30));
+
 			// Skip hidden/inactive dialogs
 			String ariaHidden = elem.getAttribute("aria-hidden");
-			if ("true".equals(ariaHidden) || !elem.isDisplayed()) continue;
+			if ("true".equals(ariaHidden)) continue;
 			return elem;
 		}
 		return null;
@@ -124,7 +127,9 @@ public class UpdateProviderPage extends ViewProviderPage {
 						By.xpath(".//button[contains(.,\"Continue w/ Original\")]"));
 				if (continueBtn.isDisplayed() && continueBtn.isEnabled()) {
 					continueBtn.click();
-					waitSeconds(2);
+
+					selenium_.waitUntil(ExpectedConditions.invisibilityOf(validationWidget));
+					// waitSeconds(2);
 					return;
 				}
 			} catch (org.openqa.selenium.NoSuchElementException ignore) {
@@ -133,17 +138,18 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 			try {
 				// Generic fallback: first displayed & enabled button
-			for (WebElement btn : validationWidget.findElements(By.tagName("button"))) {
-				if (btn.isDisplayed() && btn.isEnabled()) {
-					btn.click();
-					waitSeconds(2);
-					return;
+				for (WebElement btn : validationWidget.findElements(By.tagName("button"))) {
+					if (btn.isDisplayed() && btn.isEnabled()) {
+						btn.click();
+						waitSeconds(2);
+						return;
+					}
 				}
-			}
 			} catch (org.openqa.selenium.NoSuchElementException ignore) {
 				//Generic catch block
 			}
 		}
+		LOG.info("no validation widget");
 	}
 
 	/**

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/helper/UpdateSimpleHelper.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/helper/UpdateSimpleHelper.java
@@ -2,7 +2,9 @@ package ca.bc.gov.health.qa.autotest.plr.web.tests.helper;
 
 import java.util.*;
 
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.MaintainRequestBuilder;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.MaintainIndividualBuilder;
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.MaintainOrgBuilder;
 import ca.bc.gov.health.qa.autotest.plr.util.ProviderType;
 import org.apache.commons.lang3.StringUtils;
 
@@ -252,7 +254,7 @@ public class UpdateSimpleHelper {
 	 * @return the MaintainIndividualBuilder instance for the other provider type
 	 * @throws IllegalArgumentException if the provided type is not recognized
 	 */
-	public static MaintainIndividualBuilder getOtherProvider(Map<ProviderType, MaintainIndividualBuilder> providers, ProviderType type)
+	public static MaintainRequestBuilder getOtherProvider(Map<ProviderType, MaintainRequestBuilder> providers, ProviderType type)
 	{
 		return switch(type) {
 			case BC_PRACTITIONER -> providers.get(ProviderType.OOP_PRACTITIONER);

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/AddressType.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/AddressType.java
@@ -5,9 +5,9 @@ package ca.bc.gov.health.qa.autotest.plr.web.tests.model;
  */
 public enum AddressType {
 	/** Physical Location */
-	P("P - Physical Location"),
+	P("P - Physical location"),
 	/** Mailing Address */
-	M("M - Mailing Address");
+	M("M - Mailing address");
 
 	private final String text;
 

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/ElectronicAddressPurpose.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/ElectronicAddressPurpose.java
@@ -1,0 +1,59 @@
+package ca.bc.gov.health.qa.autotest.plr.web.tests.model;
+
+/**
+ * Enum for Electronic Address Purposes
+ */
+public enum ElectronicAddressPurpose {
+	/** Ministry Contact */
+	MINISTRY_CONTACT("MC - Ministry Contact"),
+	/** Other Contact */
+	OTHER_CONTACT("OC - Other Contact"),
+	/** Business Contact */
+	BUSINESS_CONTACT("BC - Business Contact"),
+	/** Home Contact */
+	HOME_CONTACT("HC - Home Contact"),
+	/** College Contact */
+	COLLEGE_CONTACT("CC - College Contact"),
+	/** Doctor's Contact */
+	DOCTORS_CONTACT("DC - Doctor's Contact"),
+	/** Facility Contact */
+	FACILITY_CONTACT("FC - Facility Contact");
+
+	private final String text;
+
+	ElectronicAddressPurpose(String text) {
+		this.text = text;
+	}
+
+	/**
+	 * Get the text value of the enum
+	 * @return the text value as a string
+	 */
+	public String getText() {
+		return this.text;
+	}
+
+	/**
+	 * Get the starting text before the hyphen (code)
+	 *
+	 * @return the starting text as a string
+	 */
+	public String getStartText() { return this.text.split(" ")[0]; }
+
+	/**
+	 * Get the ending text after the hyphen (description)
+	 *
+	 * @return the ending text as a string
+	 */
+	public String getEndText() { 
+		String[] parts = this.text.split(" - ");
+		return parts.length > 1 ? parts[1] : this.text; 
+	}
+
+	/**
+	 * Get the data field format "EndText (StartText)"
+	 *
+	 * @return the data field as a string
+	 */
+	public String getDataField() { return this.getEndText() + " (" + this.getStartText() + ")"; }
+}

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/TelecommunicationPurpose.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/model/TelecommunicationPurpose.java
@@ -1,0 +1,61 @@
+package ca.bc.gov.health.qa.autotest.plr.web.tests.model;
+
+/**
+ * Enum for Telecommunication Purposes
+ */
+public enum TelecommunicationPurpose {
+	/** Ministry Contact */
+	MINISTRY_CONTACT("MC - Ministry Contact"),
+	/** Other Contact */
+	OTHER_CONTACT("OC - Other Contact"),
+	/** Business Contact */
+	BUSINESS_CONTACT("BC - Business Contact"),
+	/** Home Contact */
+	HOME_CONTACT("HC - Home Contact"),
+	/** College Contact */
+	COLLEGE_CONTACT("CC - College Contact"),
+	/** Doctor's Contact */
+	DOCTORS_CONTACT("DC - Doctor's Contact"),
+	/** Facility Contact */
+	FACILITY_CONTACT("FC - Facility Contact"),
+	/** Emergency Contact */
+	EMERGENCY_CONTACT("EC - Emergency Contact");
+
+	private final String text;
+
+	TelecommunicationPurpose(String text) {
+		this.text = text;
+	}
+
+	/**
+	 * Get the text value of the enum
+	 * @return the text value as a string
+	 */
+	public String getText() {
+		return this.text;
+	}
+
+	/**
+	 * Get the starting text before the hyphen (code)
+	 *
+	 * @return the starting text as a string
+	 */
+	public String getStartText() { return this.text.split(" ")[0]; }
+
+	/**
+	 * Get the ending text after the hyphen (description)
+	 *
+	 * @return the ending text as a string
+	 */
+	public String getEndText() { 
+		String[] parts = this.text.split(" - ");
+		return parts.length > 1 ? parts[1] : this.text; 
+	}
+
+	/**
+	 * Get the data field format "EndText (StartText)"
+	 *
+	 * @return the data field as a string
+	 */
+	public String getDataField() { return this.getEndText() + " (" + this.getStartText() + ")"; }
+}

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
@@ -8,10 +8,8 @@ import static ca.bc.gov.health.qa.autotest.plr.data.UpdateProviderConstants.*;
 import ca.bc.gov.health.qa.autotest.core.util.config.Config;
 import ca.bc.gov.health.qa.autotest.core.util.config.ConfigProvider;
 import ca.bc.gov.health.qa.autotest.plr.data.InjectableData;
-import ca.bc.gov.health.qa.autotest.plr.data.PlrData;
 import ca.bc.gov.health.qa.autotest.plr.fhir.FHIRController;
 import ca.bc.gov.health.qa.autotest.plr.fhir.data.individual.IndividualMaintainConfig;
-import ca.bc.gov.health.qa.autotest.plr.fhir.data.organization.OrganizationMaintainConfig;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.MaintainRequestBuilder;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.common.model.IdentifierType;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.MaintainIndividualBuilder;
@@ -24,7 +22,6 @@ import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.ProviderSection;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.UpdateProviderPage;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.helper.UpdateSimpleHelper;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.AddressType;
-import ca.bc.gov.health.qa.autotest.plr.web.tests.model.CanadianProvince;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.CommunicationPurpose;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.ConditionType;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.EndReason;
@@ -32,7 +29,6 @@ import ca.bc.gov.health.qa.autotest.plr.web.tests.model.ElectronicAddressPurpose
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.ElectronicAddressType;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.TelecommunicationPurpose;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.TelecommunicationType;
-import ca.bc.gov.health.qa.autotest.plr.web.tests.model.USState;
 import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflow;
 import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflowManager;
 import ca.bc.gov.health.qa.autotest.runner.util.log.ExecutionLogManager;
@@ -52,7 +48,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -150,10 +145,10 @@ public class UpdateProviderTests implements SimpleTest {
     @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
     public void testAddProviderRelationships(ProviderType providerType)
     {
-        final MaintainIndividualBuilder otherProvider = getOtherProvider(defaultProviders, providerType);
+        final MaintainIndividualBuilder otherProvider = (MaintainIndividualBuilder) getOtherProvider(defaultProviders, providerType);
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         WebElement dialog = page.clickHeaderAddButton(ProviderSection.PROVIDER_RELATIONSHIPS);
@@ -183,7 +178,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         WebElement dialog = page.clickHeaderAddButton(ProviderSection.REGISTRY_USER_RELATIONSHIPS);
@@ -212,7 +207,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         WebElement dialog = page.clickHeaderAddButton(ProviderSection.WORK_LOCATIONS);
@@ -466,7 +461,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = logIn(workflowManager_, UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
         page.addWorkLocationDataBlock(null, false, "Test Name", "CC", null, false);
 
@@ -504,10 +499,10 @@ public class UpdateProviderTests implements SimpleTest {
     @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
     public void testProviderRelationshipTypes(ProviderType providerType)
     {
-        final MaintainIndividualBuilder otherProvider = getOtherProvider(defaultProviders, providerType);
+        final MaintainIndividualBuilder otherProvider = (MaintainIndividualBuilder) getOtherProvider(defaultProviders, providerType);
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         page.addProviderRelationshipDataBlock(IdentifierType.IPC, otherProvider.getIdentifier(IdentifierType.IPC),
@@ -534,10 +529,10 @@ public class UpdateProviderTests implements SimpleTest {
     @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
     public void testProviderRelationshipValidation(ProviderType providerType)
     {
-        final MaintainIndividualBuilder otherProvider = getOtherProvider(defaultProviders, providerType);
+        final MaintainIndividualBuilder otherProvider = (MaintainIndividualBuilder) getOtherProvider(defaultProviders, providerType);
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         String error = page.addProviderRelationshipDataBlock(null, otherProvider.getIdentifier(IdentifierType.IPC),
@@ -572,7 +567,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         String error = page.addRegUserRelationshipDataBlock(null, "00002855", UserType.ADMIN, true);
@@ -611,7 +606,7 @@ public class UpdateProviderTests implements SimpleTest {
 
         String identifier;
         if (providerType.equals(ProviderType.ORGANIZATION)) identifier = defaultOrg.getIdentifier(IdentifierType.IPC);
-        else identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        else identifier = getIdentifierFromBuilder(defaultProviders, providerType);
 
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
@@ -679,10 +674,10 @@ public class UpdateProviderTests implements SimpleTest {
     @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
     public void testValidateProviderRelationshipTypeCode(ProviderType providerType)
     {
-        final MaintainIndividualBuilder otherProvider = getOtherProvider(defaultProviders, providerType);
+        final MaintainIndividualBuilder otherProvider = (MaintainIndividualBuilder) getOtherProvider(defaultProviders, providerType);
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         page.clickHeaderAddButton(ProviderSection.PROVIDER_RELATIONSHIPS);
@@ -717,7 +712,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         String error = page.addProviderRelationshipDataBlock(IdentifierType.IPC, "test",
@@ -743,10 +738,10 @@ public class UpdateProviderTests implements SimpleTest {
     @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
     public void testRelatedProviderIDAndRelationship(ProviderType providerType)
     {
-        final MaintainIndividualBuilder otherProvider = getOtherProvider(defaultProviders, providerType);
+        final MaintainIndividualBuilder otherProvider = (MaintainIndividualBuilder) getOtherProvider(defaultProviders, providerType);
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         page.addProviderRelationshipDataBlock(IdentifierType.IPC, otherProvider.getIdentifier(IdentifierType.IPC),
@@ -818,7 +813,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         page.addWorkLocationDataBlock("12345", true, "Test Name", "CC", "Test Info", false);
@@ -841,7 +836,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         page.addWorkLocationDataBlock("12345", true, "Test Name", "CC", "Test Info", false);
@@ -868,7 +863,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         String error = page.addWorkLocationDataBlock("12345", true, "Test Name", "CC",
@@ -893,7 +888,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         page.addWorkLocationDataBlock("12345", false, "Test Name", "CC", "Test Info", false);
@@ -939,7 +934,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         page.clickHeaderAddButton(ProviderSection.WORK_LOCATIONS);
@@ -974,7 +969,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         page.addWorkLocationDataBlock(generateNumericString(15), true, "Test Name",
@@ -995,7 +990,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         String error = page.addWorkLocationDataBlock(generateNumericString(21), true,
@@ -1047,7 +1042,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         page.addWorkLocationDataBlock("12345", true, "Test Name", "CC", "Test Info", false);
@@ -1080,7 +1075,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         String error = page.addWorkLocationDataBlock("12345", true,
@@ -1110,7 +1105,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         page.clickHeaderAddButton(ProviderSection.WORK_LOCATIONS);

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
@@ -7,11 +7,15 @@ import static org.testng.Assert.*;
 import ca.bc.gov.health.qa.autotest.core.util.config.Config;
 import ca.bc.gov.health.qa.autotest.core.util.config.ConfigProvider;
 import ca.bc.gov.health.qa.autotest.plr.data.InjectableData;
+import ca.bc.gov.health.qa.autotest.plr.data.PlrData;
 import ca.bc.gov.health.qa.autotest.plr.fhir.FHIRController;
 import ca.bc.gov.health.qa.autotest.plr.fhir.data.individual.IndividualMaintainConfig;
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.MaintainRequestBuilder;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.common.model.IdentifierType;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.MaintainIndividualBuilder;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.model.IndividualRoleType;
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.MaintainOrgBuilder;
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.model.OrgRoleType;
 import ca.bc.gov.health.qa.autotest.plr.util.ProviderType;
 import ca.bc.gov.health.qa.autotest.plr.util.UserType;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.ProviderSection;
@@ -21,6 +25,8 @@ import ca.bc.gov.health.qa.autotest.plr.web.tests.model.AddressType;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.ConditionType;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.ElectronicAddressPurpose;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.ElectronicAddressType;
+import ca.bc.gov.health.qa.autotest.plr.web.tests.model.TelecommunicationPurpose;
+import ca.bc.gov.health.qa.autotest.plr.web.tests.model.TelecommunicationType;
 import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflow;
 import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflowManager;
 import ca.bc.gov.health.qa.autotest.runner.util.log.ExecutionLogManager;
@@ -51,7 +57,7 @@ public class UpdateProviderTests implements SimpleTest {
     private static final Path errorPath = Path.of(config_.get("data.dir")).resolve("error-list.json");
     public static JSONObject errorList;
 
-    private static final Map<ProviderType, MaintainIndividualBuilder> defaultProviders = new HashMap<>();
+    private static final Map<ProviderType, MaintainRequestBuilder> defaultProviders = new LinkedHashMap<>();
     private static final int MAX_DIS_ACTION_DES = 3000;
     private UpdateProviderTests() {
         try
@@ -82,16 +88,27 @@ public class UpdateProviderTests implements SimpleTest {
     @BeforeTest
     public void beforeTest() {
         FHIRController fhirController = new FHIRController(UserType.ADMIN);
+        
+        // Setup practitioners
         MaintainIndividualBuilder defaultBC = fhirController
                 .createIndividual(new IndividualMaintainConfig(IndividualRoleType.OPT));
         LOG.info("Created default BC provider with IPC: {}", defaultBC.getIdentifier(IdentifierType.IPC));
         MaintainIndividualBuilder defaultOOP = fhirController
                 .createIndividual(new IndividualMaintainConfig(IndividualRoleType.OOP_RECT));
-        LOG.info("Created default OOP provider with IPC: {}", defaultBC.getIdentifier(IdentifierType.IPC));
-        fhirController.close();
-
+        LOG.info("Created default OOP provider with IPC: {}", defaultOOP.getIdentifier(IdentifierType.IPC));
+        MaintainOrgBuilder defaultOrg = fhirController.createOrganization(OrgRoleType.HDS);
+        LOG.info("Created default organization provider with IPC: {}", defaultOrg.getIdentifier(IdentifierType.IPC));
         defaultProviders.put(ProviderType.BC_PRACTITIONER, defaultBC);
         defaultProviders.put(ProviderType.OOP_PRACTITIONER, defaultOOP);
+        defaultProviders.put(ProviderType.ORGANIZATION, defaultOrg);
+        
+        // Log all providers for debugging
+        LOG.info("Provider Map - BC: {}, OOP: {}, ORG: {}", 
+                getIdentifierFromBuilder(defaultProviders, ProviderType.BC_PRACTITIONER),
+                getIdentifierFromBuilder(defaultProviders, ProviderType.OOP_PRACTITIONER),
+                getIdentifierFromBuilder(defaultProviders, ProviderType.ORGANIZATION));
+        
+        fhirController.close();
     }
 
     // Update Provider - Add Conditions
@@ -100,7 +117,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         page.addConditionDataBlock("LOC", "99999", true,
@@ -126,7 +143,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         page.addConditionDataBlock("LOC", null, false, "Test",
@@ -148,7 +165,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         String error = page.addConditionDataBlock("LOC", generateNumericString(241), false,
@@ -184,7 +201,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         page.addConditionDataBlock("LOC", "99999", true,
@@ -212,7 +229,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         page.clickHeaderAddButton(ProviderSection.CONDITIONS);
@@ -251,7 +268,7 @@ public class UpdateProviderTests implements SimpleTest {
 
 		PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-		String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+		String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
 		UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
 		page.ceaseAllDataBlockUnderSection(ProviderSection.DISCIPLINARY_ACTIONS);
@@ -277,7 +294,7 @@ public class UpdateProviderTests implements SimpleTest {
 
 		PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-		String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+		String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
 		UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 		page.ceaseAllDataBlockUnderSection(ProviderSection.DISCIPLINARY_ACTIONS);
 
@@ -302,7 +319,7 @@ public class UpdateProviderTests implements SimpleTest {
 
 		PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-		String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+		String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
 		UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 		page.ceaseAllDataBlockUnderSection(ProviderSection.DISCIPLINARY_ACTIONS);
 
@@ -325,7 +342,7 @@ public class UpdateProviderTests implements SimpleTest {
 
 		PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-		String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+		String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
 		UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 		page.ceaseAllDataBlockUnderSection(ProviderSection.DISCIPLINARY_ACTIONS);
 
@@ -350,7 +367,7 @@ public class UpdateProviderTests implements SimpleTest {
 	public void testValidateProviderConditions(ProviderType providerType) {
 		PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-		String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+		String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
 		UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
 		assertEquals(page.grabActiveDataBlockCount(ProviderSection.CONDITIONS, true), 0,
@@ -375,7 +392,7 @@ public class UpdateProviderTests implements SimpleTest {
     {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         String error = page.addConditionDataBlock("LOC", "99999", true,
@@ -397,96 +414,251 @@ public class UpdateProviderTests implements SimpleTest {
     // Update Provider - Add block - Add Addresses
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testAddAddresses(ProviderType providerType) {
+        //Add valid address block 
+
+        //Open dialog to add address block and cancel. Check address was not added.
+
     }
 
     // Update Provider - Add block - Add Electronic Addresses
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testAddElectronicAddresses(ProviderType providerType) {
+        //Add valid electronic address block 
+
+        //Open dialog to add electronic address block and cancel. Check electronic address was not added.
+
+
     }
 
     // Update Provider - Add block - Add Telecommunications
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testAddTelecommunications(ProviderType providerType) {
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
+
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
+
+        // Add valid telecommunication block
+        page.addTelecommunicationDataBlock(
+                TelecommunicationType.PHONE.getText(),
+                TelecommunicationPurpose.BUSINESS_CONTACT.getText(),
+                "604",
+                "5551234",
+                "100",
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.TELECOMMUNICATIONS, true), 1,
+                "Expected 1 active telecommunication data block");
+
+        page.ceaseDataBlock(ProviderSection.TELECOMMUNICATIONS, 0);
+
+        // Open dialog to add telecommunication block and cancel. Check telecommunication was not added.
+        page.cancelAddTelecommunicationDataBlock(
+                TelecommunicationType.MOBILE.getText(),
+                TelecommunicationPurpose.HOME_CONTACT.getText(),
+                "778",
+                "5555678",
+                null,
+                effective_date(),
+                increment_year_for_effective_date());
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.TELECOMMUNICATIONS, true), 0,
+                "Expected no active telecommunication data blocks after cancelling add");
     }
 
     // Update Provider - Add block - General Address Validation
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testGeneralAddressValidation(ProviderType providerType) {
+        //Add address with address line 1 but without address line 2 and 3 - success
+
+        //Add address without address line 1 but with address line 2 - fail
+
+        //Add address in line 1 that contains a space between # and # eg 456 789 Main St- success
+
+        //Add address using address that includes the post office box and station information in line 1 address
+
+        //Add address that includes street type abbreviated
     }
 
     // Update Provider - Add block - Validate Address Line One
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateAddressLineOne(ProviderType providerType) {
+        //Enter address with line 1 exceeding 70 characters
+
+        //Enter address with line 1 blank
+
+        //Enter address with line 1 as "NO FIXED ADDRESS" - Success
+
+        //Enter address with line 1 a "UNKNOWN" -Success
+
+        //Enter address line 1 as "NA" - Success
+
     }
 
     // Update Provider - Add block - Validate Address Purpose Code
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateAddressPurposeCode(ProviderType providerType) {
+        //Verify purpose code is mandatory by not settin a value
+
+        //Verify the code set available for Purpose code
+
+        //Add address with purpose code
     }
 
     // Update Provider - Add block - Validate Address Type Code
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateAddressTypeCode(ProviderType providerType) {
-    }
+        //Verify type code is mandatory by not settin a value
+
+        //Verify the code set available for Type code
+
+        //Add address with type code
+
+}
 
     // Update Provider - Add block - Validate Address Uniqueness Rules
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateAddressUniquenessRules(ProviderType providerType) {
-    }
+        //Add address with mailing address type and MC purpose code
+
+        //Add address with mailing address type and MC contact purpose code - fail due to uniqueness rules
+
+        //Repeat previous steps with all purpose codes for mailing address type to verify uniqueness rules are working as expected for all purpose codes
+
+        //Repeat all steps for phyisical address type and verify uniqueness rules are working as expected
+}
 
     // Update Provider - Add block - Validate City
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateCity(ProviderType providerType) {
+        //Enter address with city blank
+
+        //Enter address with more than 60 characters
+
+        //Enter address with city = to 60 characters
+
     }
 
     // Update Provider - Add block - Validate Communication Purpose Type Code
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateCommunicationPurposeTypeCode(ProviderType providerType) {
+        //add telecomunication without purpose code - failure
+
+        //add electronic address without purpose code - failure
+
+        //add address without purpose code - failure
+
     }
 
     // Update Provider - Add block - Validate Electronic Address Txt
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateElectronicAddressTxt(ProviderType providerType) {
+        //add electronic address with more than 500 characters - failure
+
+        //add electronic address with field blank - failure
+
+        //add electronic address with invalid email format - failure
+
+        //add electronic address with email with one or more periods before the @ - success
+
+        //add electronic address using email with 500 charactes - success
+
     }
 
     // Update Provider - Add block - Validate Electronic Address Type Code
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateElectronicAddressTypeCode(ProviderType providerType) {
+    
+        //add electronic address without type code - failure
+
+        //add electronic address with valid type code - success
+
     }
 
     // Update Provider - Add block - Validate Postal Code
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidatePostalCode(ProviderType providerType) {
+        //Enter address with country as Brazil - postal code exceeding 25 characters - failure
+
+        //Enter address with country as Canada - postal code exceeding 25 characters - failure
+
+        //Enter address with country as Canada - with postal code as ANA NAN - success
+
     }
 
     // Update Provider - Add block - Validate Province
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateProvince(ProviderType providerType) {
+        //Enter address with country as Canada - with valid province code - success
+
+        //Enter address with country as Canada - with invalid province code - failure
+
+        //Enter address with country as Brazil - with valid state code - success
+
+        //Enter address with country as Brazil - with invalid state code - failure
+
     }
 
     // Update Provider - Add block - Validate Province and State Address Codes with Country
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateProvinceAndStateAddressCodesWithCountry(ProviderType providerType) {
+    
+        //In the add address popup verify CA has all valid provinces
+
+        //In the add address popup verify US has all valid states
+
+        //Verify that when a country other than CA or US is selected, the province/state field is a free text field
+
+        //With address other than CA or US, try to send an address without province/state - failure
+
+        //With address other than CA or US, try to send an address with provnce > 30 characters - failure
+
+        //Repeat above with province = 30 characters - success
+
     }
 
     // Update Provider - Add block - Validate Telecommunication Number
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateTelecommunicationNumber(ProviderType providerType) {
+        //Try to add telecommunication with extension > 15 characters
+
+        //Try to add teleocmmunication with number > 30 characters
+
+        //Try to add telecommunication with area code > 15 characters
+
+        //Add telecom with area code = 15 characters, nuiber 30 characters and extension 30 characters - success
     }
 
     // Update Provider - Add block - Validate Telecom Uniqueness Rules
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateTelecomUniquenessRules(ProviderType providerType) {
+        //Add telecom as fax and type MC
+
+        //Add telecom as fax and type MC contact - fail due to uniqueness rules
+
+        //repeat above with all combinations of telecom type and purpose type to verify uniqueness rules are working as expected.
     }
 
     // Update Provider - Add block - Validate Telecommunication Type Code
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateTelecommunicationTypeCode(ProviderType providerType) {
+        //Check that in the telecommunication type code dropdown, the options available are as expected
+
+        //Try to add telecommunciation without type - failure
+
     }
 
     // Update Provider - Add block - Validate eAddress Uniqueness Rules
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateEAddressUniquenessRules(ProviderType providerType) {
+        //Add electronic address with type ftp and purpose MC
+
+        //Add electronic address with type email and purpose MC contact - fail due to uniqueness rules
+
+        //repeat above with all combinations of electronic address type and purpose type to verify uniqueness rules are working as expected.
+
     }
 
     

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
@@ -22,11 +22,14 @@ import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.ProviderSection;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.UpdateProviderPage;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.helper.UpdateSimpleHelper;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.AddressType;
+import ca.bc.gov.health.qa.autotest.plr.web.tests.model.CanadianProvince;
+import ca.bc.gov.health.qa.autotest.plr.web.tests.model.CommunicationPurpose;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.ConditionType;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.ElectronicAddressPurpose;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.ElectronicAddressType;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.TelecommunicationPurpose;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.TelecommunicationType;
+import ca.bc.gov.health.qa.autotest.plr.web.tests.model.USState;
 import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflow;
 import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflowManager;
 import ca.bc.gov.health.qa.autotest.runner.util.log.ExecutionLogManager;
@@ -532,195 +535,1096 @@ public class UpdateProviderTests implements SimpleTest {
     // Update Provider - Add block - General Address Validation
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testGeneralAddressValidation(ProviderType providerType) {
-        //Add address with address line 1 but without address line 2 and 3 - success
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        //Add address without address line 1 but with address line 2 - fail
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
-        //Add address in line 1 that contains a space between # and # eg 456 789 Main St- success
+        // Add address with address line 1 but without address line 2 and 3 - success
+        String purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        page.addAddressDataBlock(
+                AddressType.M.getText(),
+                purposeCode,
+                "123 Test Street",
+                null,
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
 
-        //Add address using address that includes the post office box and station information in line 1 address
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true), 2,
+                "Expected 2 active address data blocks after adding address with line 1 only");
+        page.ceaseLastDataBlock(ProviderSection.ADDRESSES);
 
-        //Add address that includes street type abbreviated
+        // Add address without address line 1 but with address line 2 - fail
+        purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        String error = page.addAddressDataBlock(
+                AddressType.M.getText(),
+                purposeCode,
+                null,
+                "Suite 200",
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
+
+        assertEquals(error, errorList.get("missingAddressLine1"),
+                "Expected error for missing address line 1");
+
+        // Add address in line 1 that contains a space between # and # e.g., "456 789 Main St" - success
+        purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        page.addAddressDataBlock(
+                AddressType.M.getText(),
+                purposeCode,
+                "456 789 Main St",
+                null,
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true), 2,
+                "Expected 2 active address data blocks after adding address with space in line 1");
+        page.ceaseLastDataBlock(ProviderSection.ADDRESSES);
+
+        // Add address using address that includes the post office box and station information in line 1 address - success
+        purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        page.addAddressDataBlock(
+                AddressType.M.getText(),
+                purposeCode,
+                "PO Box 1234 Station Main",
+                null,
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true), 2,
+                "Expected 2 active address data blocks after adding PO Box address");
+        page.ceaseLastDataBlock(ProviderSection.ADDRESSES);
+
+        // Add address that includes street type abbreviated - success
+        purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        page.addAddressDataBlock(
+                AddressType.M.getText(),
+                purposeCode,
+                "789 Oak Ave",
+                null,
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true), 2,
+                "Expected 2 active address data blocks after adding address with abbreviated street type");
+        page.ceaseLastDataBlock(ProviderSection.ADDRESSES);
     }
 
     // Update Provider - Add block - Validate Address Line One
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateAddressLineOne(ProviderType providerType) {
-        //Enter address with line 1 exceeding 70 characters
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        //Enter address with line 1 blank
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
-        //Enter address with line 1 as "NO FIXED ADDRESS" - Success
+        // Enter address with line 1 exceeding 101 characters - fail
+        String purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        String error = page.addAddressDataBlock(
+                AddressType.M.getText(),
+                purposeCode,
+                generateAlphabetNumericString(101),
+                null,
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
 
-        //Enter address with line 1 a "UNKNOWN" -Success
+        assertEquals(error, errorList.get("addressLine1TooLong"),
+                "Expected error for address line 1 exceeding 101 characters");
 
-        //Enter address line 1 as "NA" - Success
+        // Enter address with line 1 blank - fail
+        purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        error = page.addAddressDataBlock(
+                AddressType.M.getText(),
+                purposeCode,
+                null,
+                null,
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
 
+        assertEquals(error, errorList.get("missingAddressLine1"),
+                "Expected error for blank address line 1");
+
+        // Enter address with line 1 as "NO FIXED ADDRESS" - Success
+        purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        page.addAddressDataBlock(
+                AddressType.M.getText(),
+                purposeCode,
+                "NO FIXED ADDRESS",
+                null,
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true), 2,
+                "Expected 2 active address data blocks after adding 'NO FIXED ADDRESS'");
+        page.ceaseLastDataBlock(ProviderSection.ADDRESSES);
+
+        // Enter address with line 1 as "UNKNOWN" - Success
+        purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        page.addAddressDataBlock(
+                AddressType.M.getText(),
+                purposeCode,
+                "UNKNOWN",
+                null,
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true), 2,
+                "Expected 2 active address data blocks after adding 'UNKNOWN'");
+        page.ceaseLastDataBlock(ProviderSection.ADDRESSES);
+
+        // Enter address line 1 as "NA" - Success
+        purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        page.addAddressDataBlock(
+                AddressType.M.getText(),
+                purposeCode,
+                "NA",
+                null,
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true), 2,
+                "Expected 2 active address data blocks after adding 'NA'");
+        page.ceaseLastDataBlock(ProviderSection.ADDRESSES);
     }
 
     // Update Provider - Add block - Validate Address Purpose Code
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateAddressPurposeCode(ProviderType providerType) {
-        //Verify purpose code is mandatory by not settin a value
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        //Verify the code set available for Purpose code
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
-        //Add address with purpose code
+        // Verify purpose code is mandatory by checking mandatory fields in dialog
+        page.clickHeaderAddButton(ProviderSection.ADDRESSES);
+
+        assertTrue(page.getMandatoryFields(ProviderSection.ADDRESSES).contains("Purpose"),
+                "Expected 'Purpose' to be a mandatory field when adding an address data block");
+
+        // Verify purpose code dropdown has options available
+        List<String> purposeOptions = page.getDropdownListOptions(ProviderSection.ADDRESSES, "addressPurpose");
+        purposeOptions.remove("Select One");
+        assertFalse(purposeOptions.isEmpty(),
+                "Expected purpose dropdown to have available options");
+
+        // Verify purpose options follow expected format (CODE - Description)
+        for (String option : purposeOptions) {
+            assertTrue(option.matches("^[A-Z]{2} - .+$"),
+                    "Expected purpose option to follow format 'XX - Description', found: " + option);
+        }
+
+        page.clickDialogCancelButton(ProviderSection.ADDRESSES);
+
+        // Try to add address without selecting a purpose code - should fail
+        String error = page.addAddressDataBlock(
+                AddressType.M.getText(),
+                "Select One",
+                "123 Test Street",
+                null,
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
+
+        assertEquals(error, errorList.get("errMsg5000Purpose"),
+                "Expected error message for missing purpose when adding address data block");
+
+        // Add address with valid purpose code - should succeed
+        String purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        page.addAddressDataBlock(
+                AddressType.M.getText(),
+                purposeCode,
+                "456 Valid Street",
+                null,
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true), 2,
+                "Expected 2 active address data blocks after adding address with valid purpose code");
+
+        // Verify the purpose code is displayed correctly in the data block
+        LinkedHashMap<String, String> content = page.grabDataBlockContent(ProviderSection.ADDRESSES, 1);
+        String addressPurpose = content.get("Address Purpose");
+        assertNotNull(addressPurpose,
+                "Expected 'Address Purpose' key to be present in address data block");
+        assertFalse(addressPurpose.isEmpty(),
+                "Expected purpose code to be displayed in address data block");
+
+        page.ceaseLastDataBlock(ProviderSection.ADDRESSES);
     }
 
     // Update Provider - Add block - Validate Address Type Code
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateAddressTypeCode(ProviderType providerType) {
-        //Verify type code is mandatory by not settin a value
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        //Verify the code set available for Type code
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
-        //Add address with type code
+        // Verify type code is mandatory by not setting a value
+        String error = page.addAddressDataBlock(
+                "Select One",
+                TelecommunicationPurpose.BUSINESS_CONTACT.getText(),
+                "123 Test Street",
+                null,
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
 
-}
+        assertEquals(error, errorList.get("errMsg5000AddressType"),
+                "Expected error message for missing address type when adding address data block");
+
+        // Verify the code set available for Type code
+        page.clickHeaderAddButton(ProviderSection.ADDRESSES);
+
+        List<String> typeOptions = page.getDropdownListOptions(ProviderSection.ADDRESSES, "addressType");
+        typeOptions.remove("Select One");
+        List<String> expectedOptions = Arrays.stream(AddressType.values())
+                .map(AddressType::getText).toList();
+        assertTrue(typeOptions.containsAll(expectedOptions),
+                "Expected address type dropdown options to contain all defined address types");
+
+        page.clickDialogCancelButton(ProviderSection.ADDRESSES);
+
+        // Add address with type code
+        String purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        page.addAddressDataBlock(
+                AddressType.M.getText(),
+                purposeCode,
+                "456 Valid Street",
+                null,
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true), 2,
+                "Expected 2 active address data blocks after adding address with valid type code");
+
+        page.ceaseLastDataBlock(ProviderSection.ADDRESSES);
+    }
 
     // Update Provider - Add block - Validate Address Uniqueness Rules
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateAddressUniquenessRules(ProviderType providerType) {
-        //Add address with mailing address type and MC purpose code
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        //Add address with mailing address type and MC contact purpose code - fail due to uniqueness rules
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
-        //Repeat previous steps with all purpose codes for mailing address type to verify uniqueness rules are working as expected for all purpose codes
+        // Get current active address count - there should be at least 1 existing address
+        int initialCount = page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true);
+        assertTrue(initialCount >= 1,
+                "Expected at least 1 active address data block initially");
 
-        //Repeat all steps for phyisical address type and verify uniqueness rules are working as expected
-}
+        // Get the existing address type and purpose from first address to avoid starting with same combo
+        LinkedHashMap<String, String> existingAddress = page.grabDataBlockContent(ProviderSection.ADDRESSES, 0);
+        String existingType = existingAddress.get("Address Type");
+        String existingPurpose = existingAddress.get("Address Purpose");
+
+        // Extract codes from displayed values - handles multiple formats
+        String existingTypeCode = extractCodeFromDisplayValue(existingType, true);
+        String existingPurposeCode = extractCodeFromDisplayValue(existingPurpose, false);
+
+        LOG.info("Existing address: Type={}, Purpose={}", existingTypeCode, existingPurposeCode);
+
+        // Test uniqueness rules for each address type
+        for (AddressType addressType : AddressType.values()) {
+            LOG.info("Testing uniqueness for address type: {}", addressType.getCode());
+
+            // Test each purpose code from CommunicationPurpose enum
+            for (CommunicationPurpose purpose : CommunicationPurpose.values()) {
+                String purposeCode = purpose.getCode();
+
+                // Skip if this is the existing address combo - we'd be creating a duplicate immediately
+                if (addressType.getCode().equals(existingTypeCode) &&
+                        purposeCode.equals(existingPurposeCode)) {
+                    LOG.info("Skipping existing combo: Type={}, Purpose={}", addressType.getCode(), purposeCode);
+                    continue;
+                }
+
+                LOG.info("Testing uniqueness: Type={}, Purpose={}", addressType.getCode(), purposeCode);
+
+                // First, add address with this type and purpose - should succeed
+                page.addAddressDataBlock(
+                        addressType.getText(),
+                        purpose.getText(),
+                        "123 Test Street",
+                        null,
+                        null,
+                        "Vancouver",
+                        "BC - British Columbia",
+                        "CA - CANADA",
+                        "V6B 1A1",
+                        effective_date(),
+                        increment_year_for_effective_date(),
+                        false);
+
+                int countAfterFirst = page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true);
+                assertEquals(countAfterFirst, initialCount + 1,
+                        "Expected " + (initialCount + 1) + " active address blocks after adding first address with Type=" +
+                                addressType.getCode() + ", Purpose=" + purposeCode);
+
+                // Now try to add another address with same type and purpose - should fail
+                String error = page.addAddressDataBlock(
+                        addressType.getText(),
+                        purpose.getText(),
+                        "456 Duplicate Street",
+                        null,
+                        null,
+                        "Victoria",
+                        "BC - British Columbia",
+                        "CA - CANADA",
+                        "V8V 2B2",
+                        effective_date(),
+                        increment_year_for_effective_date(),
+                        true);
+
+                // Verify uniqueness error - check for error code 2201 and address type/purpose in message
+                assertNotNull(error,
+                        "Expected error when adding duplicate address with Type=" + addressType.getCode() +
+                                ", Purpose=" + purposeCode);
+                assertTrue(error.contains("2201"),
+                        "Expected error code 2201 for uniqueness violation, got: " + error);
+
+                // Verify count didn't change after failed add
+                int countAfterDuplicate = page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true);
+                assertEquals(countAfterDuplicate, initialCount + 1,
+                        "Address count should not increase after failed duplicate add");
+
+                // Cease the address we just added to keep only the original
+                page.ceaseLastDataBlock(ProviderSection.ADDRESSES);
+
+                // Verify we're back to initial count
+                int countAfterCease = page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true);
+                assertEquals(countAfterCease, initialCount,
+                        "Expected to return to initial count after ceasing test address");
+            }
+        }
+
+        LOG.info("All address uniqueness rules verified successfully");
+    }
+
+    /**
+     * Extracts the code from a displayed value. Handles multiple formats:
+     * - "Physical location (P)" -> "P" (code in parentheses)
+     * - "P - Physical location" -> "P" (code before dash)
+     * - "Physical" -> "P" (matches enum description)
+     * - "Business Contact (BC)" -> "BC"
+     * - "BC - Business Contact" -> "BC"
+     * - "Business" -> "BC" (partial match)
+     *
+     * @param value the displayed value to extract the code from
+     * @param isAddressType true for address type, false for purpose
+     * @return the extracted code, or null if not found
+     */
+    private String extractCodeFromDisplayValue(String value, boolean isAddressType) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+
+        // Try to extract from parentheses at the end: "Physical location (P)" -> "P"
+        if (value.contains("(") && value.contains(")")) {
+            int start = value.lastIndexOf('(') + 1;
+            int end = value.lastIndexOf(')');
+            if (start < end) {
+                return value.substring(start, end);
+            }
+        }
+
+        // Try to extract code before dash: "P - Physical location" -> "P"
+        if (value.contains(" - ")) {
+            String potentialCode = value.split(" - ")[0].trim();
+            if (potentialCode.length() <= 3) { // Codes are usually 1-3 characters
+                return potentialCode;
+            }
+        }
+
+        // Try to match by description against enum values
+        if (isAddressType) {
+            for (AddressType at : AddressType.values()) {
+                if (value.toLowerCase().contains(at.getDescription().toLowerCase()) ||
+                    at.getDescription().toLowerCase().contains(value.toLowerCase())) {
+                    return at.getCode();
+                }
+            }
+        } else {
+            for (CommunicationPurpose cp : CommunicationPurpose.values()) {
+                String desc = cp.getDescription();
+                if (value.toLowerCase().contains(desc.toLowerCase()) ||
+                    desc.toLowerCase().contains(value.toLowerCase())) {
+                    return cp.getCode();
+                }
+            }
+        }
+
+        return null;
+    }
 
     // Update Provider - Add block - Validate City
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateCity(ProviderType providerType) {
-        //Enter address with city blank
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        //Enter address with more than 60 characters
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
-        //Enter address with city = to 60 characters
+        // Enter address with city blank - should fail
+        String purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        String error = page.addAddressDataBlock(
+                AddressType.M.getText(),
+                purposeCode,
+                "123 Test Street",
+                null,
+                null,
+                null, // blank city
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
 
+        assertEquals(error, errorList.get("missingCity"),
+                "Expected error for missing city");
+
+        // Enter address with city exceeding 60 characters - should fail (use raw city to skip autocomplete)
+        purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        error = page.addAddressDataBlockRawCity(
+                AddressType.M.getText(),
+                purposeCode,
+                "123 Test Street",
+                null,
+                null,
+                generateAlphabetNumericString(61), // city > 60 chars
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
+
+        assertEquals(error, errorList.get("cityTooLong"),
+                "Expected error for city exceeding 60 characters");
+
+        // Enter address with city = 60 characters - should succeed (use raw city to skip autocomplete)
+        purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        page.addAddressDataBlockRawCity(
+                AddressType.M.getText(),
+                purposeCode,
+                "123 Test Street",
+                null,
+                null,
+                generateAlphabetNumericString(60), // city = 60 chars
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true), 2,
+                "Expected 2 active address data blocks after adding address with valid city length");
+
+        page.ceaseLastDataBlock(ProviderSection.ADDRESSES);
     }
 
     // Update Provider - Add block - Validate Communication Purpose Type Code
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateCommunicationPurposeTypeCode(ProviderType providerType) {
-        //add telecomunication without purpose code - failure
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        //add electronic address without purpose code - failure
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
-        //add address without purpose code - failure
+        // Add telecommunication without purpose code - should fail - Not Applies. Telecommunicaiton purpose is selected automatically and no default is on the list.
+        /*String error = page.addTelecommunicationDataBlock(
+                TelecommunicationType.PHONE.getText(),
+                "Select One", // no purpose code
+                "604",
+                "5551234",
+                null,
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
 
+        assertEquals(error, errorList.get("errMsg5000Purpose"),
+                "Expected error for missing purpose code when adding telecommunication");*/
+
+        // Add electronic address without purpose code - should fail
+        String error = page.addElectronicAddressDataBlock(
+                ElectronicAddressType.EMAIL.getText(),
+                "Select One", // no purpose code
+                "test@example.com",
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
+
+        assertEquals(error, errorList.get("errMsg5000Purpose"),
+                "Expected error for missing purpose code when adding electronic address");
+
+        // Add address without purpose code - should fail
+        error = page.addAddressDataBlock(
+                AddressType.M.getText(),
+                "Select One", // no purpose code
+                "123 Test Street",
+                null,
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
+
+        assertEquals(error, errorList.get("errMsg5000Purpose"),
+                "Expected error for missing purpose code when adding address");
     }
 
     // Update Provider - Add block - Validate Electronic Address Txt
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateElectronicAddressTxt(ProviderType providerType) {
-        //add electronic address with more than 500 characters - failure
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        //add electronic address with field blank - failure
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
-        //add electronic address with invalid email format - failure
+        // Add electronic address with more than 500 characters - failure
+        String error = page.addElectronicAddressDataBlock(
+                ElectronicAddressType.EMAIL.getText(),
+                TelecommunicationPurpose.BUSINESS_CONTACT.getText(),
+                generateAlphabetNumericString(501) + "@test.com", // > 500 chars total
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
 
-        //add electronic address with email with one or more periods before the @ - success
+        assertEquals(error, errorList.get("errMsg5003ElectronicAddress"),
+                "Expected error for electronic address exceeding 500 characters");
 
-        //add electronic address using email with 500 charactes - success
+        // Add electronic address with field blank - failure
+        error = page.addElectronicAddressDataBlock(
+                ElectronicAddressType.EMAIL.getText(),
+                TelecommunicationPurpose.BUSINESS_CONTACT.getText(),
+                null, // blank address
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
 
+        assertEquals(error, errorList.get("errMsg5000EAddress"),
+                "Expected error for missing electronic address");
+
+        // Add electronic address with invalid email format - failure
+        error = page.addElectronicAddressDataBlock(
+                ElectronicAddressType.EMAIL.getText(),
+                TelecommunicationPurpose.BUSINESS_CONTACT.getText(),
+                "invalid-email-format", // no @ symbol
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
+
+        assertEquals(error, errorList.get("errMsgprovider7013"),
+                "Expected error for invalid email format");
+
+        // Add electronic address with email with one or more periods before the @ - success
+        page.addElectronicAddressDataBlock(
+                ElectronicAddressType.EMAIL.getText(),
+                TelecommunicationPurpose.BUSINESS_CONTACT.getText(),
+                "test.user.name@example.com", // periods before @
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ELECTRONIC_ADDRESSES, true), 1,
+                "Expected 1 active electronic address data block after adding email with periods");
+
+        page.ceaseDataBlock(ProviderSection.ELECTRONIC_ADDRESSES, 0);
+
+        // Add electronic address using email with 500 characters - success
+        String longEmail = generateAlphabetNumericString(490) + "@test.com"; // 500 chars total
+        page.addElectronicAddressDataBlock(
+                ElectronicAddressType.EMAIL.getText(),
+                TelecommunicationPurpose.HOME_CONTACT.getText(),
+                longEmail,
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ELECTRONIC_ADDRESSES, true), 1,
+                "Expected 1 active electronic address data block after adding 500 char email");
+
+        page.ceaseDataBlock(ProviderSection.ELECTRONIC_ADDRESSES, 0);
     }
 
     // Update Provider - Add block - Validate Electronic Address Type Code
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateElectronicAddressTypeCode(ProviderType providerType) {
-    
-        //add electronic address without type code - failure
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        //add electronic address with valid type code - success
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
+        // Add electronic address without type code - failure
+        String error = page.addElectronicAddressDataBlock(
+                "Select One", // no type
+                TelecommunicationPurpose.BUSINESS_CONTACT.getText(),
+                "test@example.com",
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
+
+        assertEquals(error, errorList.get("errMsg5000Type"),
+                "Expected error for missing electronic address type");
+
+        // Add electronic address with valid type code (EMAIL) - success
+        page.addElectronicAddressDataBlock(
+                ElectronicAddressType.EMAIL.getText(),
+                TelecommunicationPurpose.BUSINESS_CONTACT.getText(),
+                "test@example.com",
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ELECTRONIC_ADDRESSES, true), 1,
+                "Expected 1 active electronic address data block after adding with EMAIL type");
+
+        page.ceaseDataBlock(ProviderSection.ELECTRONIC_ADDRESSES, 0);
+
+        // Add electronic address with valid type code (FTP) - success
+        page.addElectronicAddressDataBlock(
+                ElectronicAddressType.FTP.getText(),
+                TelecommunicationPurpose.HOME_CONTACT.getText(),
+                "ftp://example.com/files",
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ELECTRONIC_ADDRESSES, true), 1,
+                "Expected 1 active electronic address data block after adding with FTP type");
+
+        page.ceaseDataBlock(ProviderSection.ELECTRONIC_ADDRESSES, 0);
+
+        // Add electronic address with valid type code (HTTP) - success
+        page.addElectronicAddressDataBlock(
+                ElectronicAddressType.HTTP.getText(),
+                TelecommunicationPurpose.OTHER_CONTACT.getText(),
+                "https://www.example.com",
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ELECTRONIC_ADDRESSES, true), 1,
+                "Expected 1 active electronic address data block after adding with HTTP type");
+
+        page.ceaseDataBlock(ProviderSection.ELECTRONIC_ADDRESSES, 0);
     }
 
     // Update Provider - Add block - Validate Postal Code
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidatePostalCode(ProviderType providerType) {
-        //Enter address with country as Brazil - postal code exceeding 25 characters - failure
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        //Enter address with country as Canada - postal code exceeding 25 characters - failure
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
-        //Enter address with country as Canada - with postal code as ANA NAN - success
+        // Enter address with country as Canada - postal code with invalid format - failure
+        String purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        String error = page.addAddressDataBlock(
+                AddressType.M.getText(),
+                purposeCode,
+                "123 Test Street",
+                null,
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "INVALID", // invalid format (not ANA NAN or ANANAN)
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
 
-    }
+        assertEquals(error, errorList.get("errMsg7009"),
+                "Expected error for invalid Canadian postal code format");
 
-    // Update Provider - Add block - Validate Province
-    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
-    public void testValidateProvince(ProviderType providerType) {
-        //Enter address with country as Canada - with valid province code - success
+        // Enter address with country as Canada - postal code exceeding 25 characters - failure
+        purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        error = page.addAddressDataBlock(
+                AddressType.M.getText(),
+                purposeCode,
+                "123 Test Street",
+                null,
+                null,
+                "Vancouver",
+                "Sao Paulo",
+                "BR - BRAZIL",
+                generateAlphabetNumericString(26), // > 25 chars
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
 
-        //Enter address with country as Canada - with invalid province code - failure
+        assertEquals(error, errorList.get("errMsg5003PostalCode"),
+                "Expected error for postal code exceeding 25 characters (country not Canada)");
 
-        //Enter address with country as Brazil - with valid state code - success
+        // Enter address with country as Canada - with postal code as ANA NAN (valid format) - success
+        purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
+        page.addAddressDataBlock(
+                AddressType.M.getText(),
+                purposeCode,
+                "123 Test Street",
+                null,
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1", // valid Canadian postal code format
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
 
-        //Enter address with country as Brazil - with invalid state code - failure
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true), 2,
+                "Expected 2 active address data blocks after adding address with valid postal code");
 
-    }
-
-    // Update Provider - Add block - Validate Province and State Address Codes with Country
-    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
-    public void testValidateProvinceAndStateAddressCodesWithCountry(ProviderType providerType) {
-    
-        //In the add address popup verify CA has all valid provinces
-
-        //In the add address popup verify US has all valid states
-
-        //Verify that when a country other than CA or US is selected, the province/state field is a free text field
-
-        //With address other than CA or US, try to send an address without province/state - failure
-
-        //With address other than CA or US, try to send an address with provnce > 30 characters - failure
-
-        //Repeat above with province = 30 characters - success
-
+        page.ceaseLastDataBlock(ProviderSection.ADDRESSES);
     }
 
     // Update Provider - Add block - Validate Telecommunication Number
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateTelecommunicationNumber(ProviderType providerType) {
-        //Try to add telecommunication with extension > 15 characters
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        //Try to add teleocmmunication with number > 30 characters
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
-        //Try to add telecommunication with area code > 15 characters
+        // Try to add telecommunication with extension > 15 characters - failure
+        String error = page.addTelecommunicationDataBlock(
+                TelecommunicationType.PHONE.getText(),
+                TelecommunicationPurpose.BUSINESS_CONTACT.getText(),
+                "604",
+                "5551234",
+                generateNumericString(16), // extension > 15 chars
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
 
-        //Add telecom with area code = 15 characters, nuiber 30 characters and extension 30 characters - success
+        assertEquals(error, errorList.get("errMsg5003TelecomExtension"),
+                "Expected error for extension exceeding 15 characters");
+
+        // Try to add telecommunication with number > 30 characters - failure
+        error = page.addTelecommunicationDataBlock(
+                TelecommunicationType.PHONE.getText(),
+                TelecommunicationPurpose.BUSINESS_CONTACT.getText(),
+                "604",
+                generateNumericString(31), // phone number > 30 chars
+                null,
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
+
+        assertEquals(error, errorList.get("errMsg5003TelecomPhoneNumber"),
+                "Expected error for phone number exceeding 30 characters");
+
+        // Try to add telecommunication with area code > 15 characters - failure
+        error = page.addTelecommunicationDataBlock(
+                TelecommunicationType.PHONE.getText(),
+                TelecommunicationPurpose.BUSINESS_CONTACT.getText(),
+                generateNumericString(16), // area code > 15 chars
+                "5551234",
+                null,
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
+
+        assertEquals(error, errorList.get("errMsg5003TelecomAreaCode"),
+                "Expected error for area code exceeding 15 characters");
+
+        // Add telecom with area code = 15 characters, number = 30 characters and extension = 15 characters - success
+        page.addTelecommunicationDataBlock(
+                TelecommunicationType.PHONE.getText(),
+                TelecommunicationPurpose.BUSINESS_CONTACT.getText(),
+                generateNumericString(15), // area code = 15 chars
+                generateNumericString(30), // phone number = 30 chars
+                generateNumericString(15), // extension = 15 chars
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.TELECOMMUNICATIONS, true), 1,
+                "Expected 1 active telecommunication data block after adding with max valid lengths");
+
+        page.ceaseDataBlock(ProviderSection.TELECOMMUNICATIONS, 0);
     }
 
     // Update Provider - Add block - Validate Telecom Uniqueness Rules
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateTelecomUniquenessRules(ProviderType providerType) {
-        //Add telecom as fax and type MC
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        //Add telecom as fax and type MC contact - fail due to uniqueness rules
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
-        //repeat above with all combinations of telecom type and purpose type to verify uniqueness rules are working as expected.
+        // Get current active telecom count - there should be at least 0 existing telecom blocks
+        int initialCount = page.grabActiveDataBlockCount(ProviderSection.TELECOMMUNICATIONS, true);
+
+        // If there is at least one telecom block, get its type and purpose to avoid immediate duplicate
+        String existingTypeCode = null;
+        String existingPurposeCode = null;
+        if (initialCount > 0) {
+            LinkedHashMap<String, String> existingTelecom = page.grabDataBlockContent(ProviderSection.TELECOMMUNICATIONS, 0);
+            String existingType = existingTelecom.get("Telecommunication Type");
+            String existingPurpose = existingTelecom.get("Telecommunication Purpose");
+            existingTypeCode = extractCodeFromDisplayValue(existingType, true);
+            existingPurposeCode = extractCodeFromDisplayValue(existingPurpose, false);
+        }
+
+        // Loop through all combinations of telecom type and purpose
+        for (TelecommunicationType telecomType : TelecommunicationType.values()) {
+            for (CommunicationPurpose purpose : CommunicationPurpose.values()) {
+                String typeCode = telecomType.getText();
+                String purposeText = purpose.getText();
+
+                // Skip if this is the existing block combo
+                if (existingTypeCode != null && existingPurposeCode != null &&
+                    typeCode.contains(existingTypeCode) && purposeText.contains(existingPurposeCode)) {
+                    continue;
+                }
+
+                // Add telecom block with this type and purpose - should succeed
+                page.addTelecommunicationDataBlock(
+                        typeCode,
+                        purposeText,
+                        "604",
+                        "5551234",
+                        null,
+                        effective_date(),
+                        increment_year_for_effective_date(),
+                        false);
+
+                int countAfterFirst = page.grabActiveDataBlockCount(ProviderSection.TELECOMMUNICATIONS, true);
+                assertEquals(countAfterFirst, initialCount + 1,
+                        "Expected " + (initialCount + 1) + " active telecom blocks after adding first with Type=" + typeCode + ", Purpose=" + purposeText);
+
+                // Try to add another telecom block with same type and purpose - should fail
+                String error = page.addTelecommunicationDataBlock(
+                        typeCode,
+                        purposeText,
+                        "778",
+                        "5555678",
+                        null,
+                        effective_date(),
+                        increment_year_for_effective_date(),
+                        true);
+
+                // Verify uniqueness error - check for error code 2201 and type/purpose in message
+                assertNotNull(error,
+                        "Expected error when adding duplicate telecom with Type=" + typeCode + ", Purpose=" + purposeText);
+                assertTrue(error.contains("2201"),
+                        "Expected error code 2201 for uniqueness violation, got: " + error);
+
+                // Verify count didn't change after failed add
+                int countAfterDuplicate = page.grabActiveDataBlockCount(ProviderSection.TELECOMMUNICATIONS, true);
+                assertEquals(countAfterDuplicate, initialCount + 1,
+                        "Telecom count should not increase after failed duplicate add");
+
+                // Cease the telecom block we just added to keep only the original
+                page.ceaseLastDataBlock(ProviderSection.TELECOMMUNICATIONS);
+
+                // Verify we're back to initial count
+                int countAfterCease = page.grabActiveDataBlockCount(ProviderSection.TELECOMMUNICATIONS, true);
+                assertEquals(countAfterCease, initialCount,
+                        "Expected to return to initial count after ceasing test telecom block");
+            }
+        }
     }
 
     // Update Provider - Add block - Validate Telecommunication Type Code
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateTelecommunicationTypeCode(ProviderType providerType) {
-        //Check that in the telecommunication type code dropdown, the options available are as expected
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        //Try to add telecommunciation without type - failure
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
+        // Verify telecommunication type dropdown options
+        page.clickHeaderAddButton(ProviderSection.TELECOMMUNICATIONS);
+
+        waitSeconds(2);
+
+        List<String> typeOptions = page.getDropdownListOptions(ProviderSection.TELECOMMUNICATIONS, "telecomType");
+        typeOptions.remove("Select One");
+
+        List<String> expectedOptions = Arrays.stream(TelecommunicationType.values())
+                .map(TelecommunicationType::getText).toList();
+        assertTrue(typeOptions.containsAll(expectedOptions),
+                "Expected telecommunication type dropdown options to contain all defined types");
+        page.clickDialogCancelButton(ProviderSection.TELECOMMUNICATIONS);
+
+        // Try to add telecommunication without type - should fail
+        String error = page.addTelecommunicationDataBlock(
+                "Select One",
+                TelecommunicationPurpose.BUSINESS_CONTACT.getText(),
+                "604",
+                "5551234",
+                null,
+                effective_date(),
+                increment_year_for_effective_date(),
+                true);
+        assertEquals(error, errorList.get("errMsg5000Type"),
+                "Expected error message for missing telecommunication type when adding telecommunication data block");
     }
+
 
     // Update Provider - Add block - Validate eAddress Uniqueness Rules
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testValidateEAddressUniquenessRules(ProviderType providerType) {
-        //Add electronic address with type ftp and purpose MC
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        //Add electronic address with type email and purpose MC contact - fail due to uniqueness rules
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
-        //repeat above with all combinations of electronic address type and purpose type to verify uniqueness rules are working as expected.
+        // Cease all existing electronic address blocks to start fresh
+        int blockCount = page.grabActiveDataBlockCount(ProviderSection.ELECTRONIC_ADDRESSES, true);
+        for (int i = blockCount - 1; i >= 0; i--) {
+                page.ceaseDataBlock(ProviderSection.ELECTRONIC_ADDRESSES, i);
+        }
 
-    }
+        int initialCount = page.grabActiveDataBlockCount(ProviderSection.ELECTRONIC_ADDRESSES, true);
 
-    
+        for (ElectronicAddressType eType : ElectronicAddressType.values()) {
+                String typeText = eType.getText();
+                //default value for email, change for other types
+                String value = "test@example.com";
+                if (eType == ElectronicAddressType.FTP) value = "ftp://example.com";
+                if (eType == ElectronicAddressType.HTTP) value = "https://example.com";
+
+                for (ElectronicAddressPurpose purpose : ElectronicAddressPurpose.values()) {
+                        String purposeText = purpose.getText();
+
+                        // 1. Add eType with this purpose (should succeed)
+                        page.addElectronicAddressDataBlock(
+                                typeText,
+                                purposeText,
+                                value,
+                                effective_date(),
+                                increment_year_for_effective_date(),
+                                false);
+
+                        int countAfterFirst = page.grabActiveDataBlockCount(ProviderSection.ELECTRONIC_ADDRESSES, true);
+                        assertEquals(countAfterFirst, initialCount + 1,
+                                "Expected " + (initialCount + 1) + " active electronic address blocks after adding " + typeText + " with Purpose=" + purposeText);
+                        // 2. Try to add duplicate eType (should fail)
+                        String error = page.addElectronicAddressDataBlock(
+                                typeText,
+                                purposeText,
+                                "duplicate@example.com",
+                                effective_date(),
+                                increment_year_for_effective_date(),
+                                true);
+                        assertNotNull(error,
+                                "Expected error when adding duplicate " + typeText + " with Purpose=" + purposeText);
+                        assertTrue(error.contains("2201"),
+                                "Expected error code 2201 for uniqueness violation, got: " + error);
+
+                        // Cease eType and repeat for next purpose
+                        page.ceaseLastDataBlock(ProviderSection.ELECTRONIC_ADDRESSES);
+
+                        int countAfterCease = page.grabActiveDataBlockCount(ProviderSection.ELECTRONIC_ADDRESSES, true);
+                        assertEquals(countAfterCease, initialCount,
+                                "Expected to return to initial count after ceasing " + typeText + " for Purpose=" + purposeText);
+                }
+        }
+
+   }
+
+    /**
+     * Tries to wait some number of seconds. Will fail the test used in if interrupted.
+	 * TODO this should be used as little as possible in favour of selenium implicit waits.
+     *
+     * @param second the number of seconds to wait.
+     */
+        public void waitSeconds(int second) {
+		try {
+			Thread.sleep(1000L * second);
+		} catch (InterruptedException e) {
+			fail(e.getMessage());
+		}
+	}
 }

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
@@ -17,7 +17,10 @@ import ca.bc.gov.health.qa.autotest.plr.util.UserType;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.ProviderSection;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.UpdateProviderPage;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.helper.UpdateSimpleHelper;
+import ca.bc.gov.health.qa.autotest.plr.web.tests.model.AddressType;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.ConditionType;
+import ca.bc.gov.health.qa.autotest.plr.web.tests.model.ElectronicAddressPurpose;
+import ca.bc.gov.health.qa.autotest.plr.web.tests.model.ElectronicAddressType;
 import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflow;
 import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflowManager;
 import ca.bc.gov.health.qa.autotest.runner.util.log.ExecutionLogManager;
@@ -390,4 +393,101 @@ public class UpdateProviderTests implements SimpleTest {
 
         page.ceaseDataBlock(ProviderSection.CONDITIONS, 0);
     }
+
+    // Update Provider - Add block - Add Addresses
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testAddAddresses(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Add Electronic Addresses
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testAddElectronicAddresses(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Add Telecommunications
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testAddTelecommunications(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - General Address Validation
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testGeneralAddressValidation(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Validate Address Line One
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateAddressLineOne(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Validate Address Purpose Code
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateAddressPurposeCode(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Validate Address Type Code
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateAddressTypeCode(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Validate Address Uniqueness Rules
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateAddressUniquenessRules(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Validate City
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateCity(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Validate Communication Purpose Type Code
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateCommunicationPurposeTypeCode(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Validate Electronic Address Txt
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateElectronicAddressTxt(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Validate Electronic Address Type Code
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateElectronicAddressTypeCode(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Validate Postal Code
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidatePostalCode(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Validate Province
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateProvince(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Validate Province and State Address Codes with Country
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateProvinceAndStateAddressCodesWithCountry(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Validate Telecommunication Number
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateTelecommunicationNumber(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Validate Telecom Uniqueness Rules
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateTelecomUniquenessRules(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Validate Telecommunication Type Code
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateTelecommunicationTypeCode(ProviderType providerType) {
+    }
+
+    // Update Provider - Add block - Validate eAddress Uniqueness Rules
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateEAddressUniquenessRules(ProviderType providerType) {
+    }
+
+    
 }

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
@@ -414,20 +414,81 @@ public class UpdateProviderTests implements SimpleTest {
     // Update Provider - Add block - Add Addresses
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testAddAddresses(ProviderType providerType) {
-        //Add valid address block 
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        //Open dialog to add address block and cancel. Check address was not added.
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
+        // Add valid address block
+        page.addAddressDataBlock(
+                AddressType.M.getText(),
+                TelecommunicationPurpose.BUSINESS_CONTACT.getText(),
+                "123 Test Street",
+                "Suite 100",
+                null,
+                "Vancouver",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V6B 1A1",
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true), 2,
+                "Expected 2 active address data block");
+
+        page.ceaseDataBlock(ProviderSection.ADDRESSES, 1);
+
+        // Open dialog to add address block and cancel. Check address was not added.
+        page.cancelAddAddressDataBlock(
+                AddressType.M.getText(),
+                TelecommunicationPurpose.HOME_CONTACT.getText(),
+                "456 Cancel Ave",
+                null,
+                null,
+                "Victoria",
+                "BC - British Columbia",
+                "CA - CANADA",
+                "V8V 2B2",
+                effective_date(),
+                increment_year_for_effective_date());
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ADDRESSES, true), 1,
+                "Expected no active address data blocks after cancelling add");
     }
 
     // Update Provider - Add block - Add Electronic Addresses
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testAddElectronicAddresses(ProviderType providerType) {
-        //Add valid electronic address block 
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        //Open dialog to add electronic address block and cancel. Check electronic address was not added.
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
+        // Add valid electronic address block
+        page.addElectronicAddressDataBlock(
+                ElectronicAddressType.EMAIL.getText(),
+                TelecommunicationPurpose.BUSINESS_CONTACT.getText(),
+                "test@example.com",
+                effective_date(),
+                increment_year_for_effective_date(),
+                false);
 
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ELECTRONIC_ADDRESSES, true), 1,
+                "Expected 1 active electronic address data block");
+
+        page.ceaseDataBlock(ProviderSection.ELECTRONIC_ADDRESSES, 0);
+
+        // Open dialog to add electronic address block and cancel. Check electronic address was not added.
+        page.cancelAddElectronicAddressDataBlock(
+                ElectronicAddressType.HTTP.getText(),
+                TelecommunicationPurpose.HOME_CONTACT.getText(),
+                "https://www.example.com",
+                effective_date(),
+                increment_year_for_effective_date());
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.ELECTRONIC_ADDRESSES, true), 0,
+                "Expected no active electronic address data blocks after cancelling add");
     }
 
     // Update Provider - Add block - Add Telecommunications


### PR DESCRIPTION
Tests for Adding blocks for ElectronicAddress, Address, and Telecommunications for view provider screen completed.
A couple of notes:

For Validate Electronic Address Text - Failing due to issue not displaying error code with incorrect email format. It will fail.
For Validate Postal Code - Validation for postal code when more than 25 characters takes too long to open - this I would consider it to be some kind of performance issue for the front end

Following test cases steps either do not apply to the webapp or are being covered by other test cases:
1. Update Provider - Add block - Validate Province
2. Update Provider - Add block - Validate Province and State Address Codes with Country