### PR TITLE
Feature/plr 610 - Update Work Locations

### DIFF
--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateOrganizationPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateOrganizationPage.java
@@ -98,7 +98,7 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 	 * @param index the index of the data block to update
 	 */
 	@Override
-	public void clickDataBlockUpdateButton(ProviderSection section, int index) {
+	public WebElement clickDataBlockUpdateButton(ProviderSection section, int index) {
 		String selectCss = getDataBlockHeaderUpdateButtonSelector(section, index);
 		selenium_.waitUntil(ExpectedConditions.elementToBeClickable(By.cssSelector(selectCss)));
 		WebElement updateButton = selenium_.findElementByCss(selectCss);
@@ -123,6 +123,7 @@ public class UpdateOrganizationPage extends UpdateProviderPage {
 		}
 			
 		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return selenium_.findElementByCss(dialogCss);
 	}
 
 	/**

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -527,7 +527,8 @@ public class UpdateProviderPage extends ViewProviderPage {
 		wlName.clear();
 		if(!StringUtils.isEmpty(name)) wlName.sendKeys(name);
 
-		setDropdownListByVisibleText(ProviderSection.WORK_LOCATIONS, "providerType", providerType);
+		if (providerType != null)
+			setDropdownListByVisibleText(ProviderSection.WORK_LOCATIONS, "providerType", providerType);
 
 		String addressInfoCss = dialogCss + " > textarea#" + formName + "\\:additionalInfo";
 		WebElement addressInfoInput = selenium_.findElement(By.cssSelector(addressInfoCss));

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -502,7 +502,7 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 	/**
 	 * fill the Work Location Data Block in update scenario,
-	 * the effective date fields will not be filled in this case since they are already set
+	 * the effective date fields cannot be manually selected, will fill in hardcoded values
 	 * @param defaultFlag the default flag to indicate whether to check the default flag checkbox
 	 * @param name the name to input
 	 * @param providerType the provider type to select
@@ -520,8 +520,6 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 		String defaultFlagCss = dialogCss + " > div#" + formName + "\\:defaultFlag > div > span";
 		WebElement defaultFlagCheckbox = selenium_.findElement(By.cssSelector(defaultFlagCss));
-		LOG.info(getChkBoxState(ProviderSection.WORK_LOCATIONS, defaultFlagCheckbox));
-		LOG.info(defaultFlag);
 		if (getChkBoxState(ProviderSection.WORK_LOCATIONS, defaultFlagCheckbox) != defaultFlag) defaultFlagCheckbox.click();
 
 		String wlNameCss = dialogCss+" >input#"+formName+"\\:name";
@@ -537,6 +535,8 @@ public class UpdateProviderPage extends ViewProviderPage {
 		if(!StringUtils.isEmpty(addressInfo)) addressInfoInput.sendKeys(addressInfo);
 
 		setEndReasonByVisibleText(ProviderSection.WORK_LOCATIONS, endReason.getText());
+
+		setDialogEffectiveFromAndEffectiveTo(ProviderSection.WORK_LOCATIONS, "2000-01-01", "2999-01-01");
 	}
 
 	/**

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -208,8 +208,9 @@ public class UpdateProviderPage extends ViewProviderPage {
      *
      * @param section the provider section to find the data block's update button within
      * @param index the specific index of the data block to find and click the update button for
+	 * @return the WebElement of the dialog content after clicking the update button and waiting for the dialog to be visible
      */
-	public void clickDataBlockUpdateButton(ProviderSection section, int index) {
+	public WebElement clickDataBlockUpdateButton(ProviderSection section, int index) {
 		String selectCss;
 		if (section.equals(ProviderSection.WORK_LOCATIONS)) {
 			expandDataBlock(section, index, true);
@@ -229,6 +230,7 @@ public class UpdateProviderPage extends ViewProviderPage {
 		String dialogCss = getDialogCss(section);
 		WebElement visibleElement = selenium_
 				.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return selenium_.findElementByCss(dialogCss);
 	}
 
 	/**
@@ -264,7 +266,7 @@ public class UpdateProviderPage extends ViewProviderPage {
 	{
 		String formName = DIALOG_MAP.get(section).getFormName();
 		String dialogCss = getDialogCss(section);
-		String checkBoxCss = dialogCss + " > div#" + formName + "\\:" + checkBoxName;
+		String checkBoxCss = dialogCss + " > div#" + formName + "\\:" + checkBoxName + " > div > span";
 		WebElement checkBox = selenium_.findElement(By.cssSelector(checkBoxCss));
 		return getChkBoxState(section, checkBox);
 	}
@@ -516,8 +518,10 @@ public class UpdateProviderPage extends ViewProviderPage {
 		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
 		waitSeconds(2);
 
-		String defaultFlagCss = dialogCss + " > div#" + formName + "\\:defaultFlag";
+		String defaultFlagCss = dialogCss + " > div#" + formName + "\\:defaultFlag > div > span";
 		WebElement defaultFlagCheckbox = selenium_.findElement(By.cssSelector(defaultFlagCss));
+		LOG.info(getChkBoxState(ProviderSection.WORK_LOCATIONS, defaultFlagCheckbox));
+		LOG.info(defaultFlag);
 		if (getChkBoxState(ProviderSection.WORK_LOCATIONS, defaultFlagCheckbox) != defaultFlag) defaultFlagCheckbox.click();
 
 		String wlNameCss = dialogCss+" >input#"+formName+"\\:name";

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/ViewProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/ViewProviderPage.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.ViewHeaderFragment;
+import ca.bc.gov.health.qa.autotest.runner.util.log.ExecutionLogManager;
+import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -23,6 +25,8 @@ import ca.bc.gov.health.qa.autotest.runner.util.selenium.pages.BasicWebPage;
 public class ViewProviderPage
 extends BasicWebPage
 {
+    private static final Logger LOG = ExecutionLogManager.getLogger();
+
     private static final Pattern DATA_KEY_SUFFIX_PATTERN = Pattern.compile(":$");
 
     private final ViewHeaderFragment viewHeader_;

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/helper/UpdateSimpleHelper.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/helper/UpdateSimpleHelper.java
@@ -1,7 +1,9 @@
 package ca.bc.gov.health.qa.autotest.plr.web.tests.helper;
 
-import java.util.Random;
+import java.util.*;
 
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.MaintainIndividualBuilder;
+import ca.bc.gov.health.qa.autotest.plr.util.ProviderType;
 import org.apache.commons.lang3.StringUtils;
 
 import static org.testng.Assert.assertFalse;
@@ -9,12 +11,6 @@ import static org.testng.Assert.assertTrue;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
 
 public class UpdateSimpleHelper {
 
@@ -247,6 +243,22 @@ public class UpdateSimpleHelper {
 		Collections.sort(arr2);
 		// Compare the sorted arrays using Arrays.equals()
 		return arr1.equals(arr2);
+	}
+
+	/**
+	 * Get the other provider's MaintainIndividualBuilder based on the given provider type.
+	 * @param providers a map containing the MaintainIndividualBuilder instances for each provider type
+	 * @param type the provider type for which to get the other provider's MaintainIndividualBuilder
+	 * @return the MaintainIndividualBuilder instance for the other provider type
+	 * @throws IllegalArgumentException if the provided type is not recognized
+	 */
+	public static MaintainIndividualBuilder getOtherProvider(Map<ProviderType, MaintainIndividualBuilder> providers, ProviderType type)
+	{
+		return switch(type) {
+			case BC_PRACTITIONER -> providers.get(ProviderType.OOP_PRACTITIONER);
+			case OOP_PRACTITIONER -> providers.get(ProviderType.BC_PRACTITIONER);
+			default -> throw new IllegalArgumentException(); // should not occur
+		};
 	}
 	
 	

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
@@ -832,6 +832,33 @@ public class UpdateProviderTests implements SimpleTest {
         page.ceaseDataBlock(ProviderSection.WORK_LOCATIONS, 0);
     }
 
+    // Update Provider - Validate Update Work Location Additional Addressee
+    @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
+    public void testValidateWorkLocationAdditionalAddresseeUpdate(ProviderType providerType)
+    {
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
+
+        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
+
+        page.addWorkLocationDataBlock("12345", true, "Test Name", "CC", "Test Info", false);
+
+        String error = page.updateWorkLocationDataBlock(true, "Test Name", "CC",
+                generateAlphabetNumericString(241), EndReason.CHG, true);
+
+        assertEquals(error, errorList.get("WLAddressInfoTooLong"),
+                "Expected error message for addressee info exceeding max length when updating work location data block");
+
+        page.updateWorkLocationDataBlock(false, "Test Name", "CC", "", EndReason.CHG, false);
+
+        Map<String,String> wlContent = page.grabDataBlockContent(ProviderSection.WORK_LOCATIONS, 0);
+
+        assertEquals(wlContent.get("Work Location Details-0-Additional Info"), "",
+                "Expected empty string for additional addressee info in work location data block when no additional addressee info is provided during update");
+
+        page.ceaseDataBlock(ProviderSection.WORK_LOCATIONS, 0);
+    }
+
     // Update Provider - Validate Work Location Additional Addressee
     @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
     public void testValidateWorkLocationAdditionalAddressee(ProviderType providerType)

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
@@ -10,9 +10,12 @@ import ca.bc.gov.health.qa.autotest.core.util.config.ConfigProvider;
 import ca.bc.gov.health.qa.autotest.plr.data.InjectableData;
 import ca.bc.gov.health.qa.autotest.plr.fhir.FHIRController;
 import ca.bc.gov.health.qa.autotest.plr.fhir.data.individual.IndividualMaintainConfig;
+import ca.bc.gov.health.qa.autotest.plr.fhir.data.organization.OrganizationMaintainConfig;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.common.model.IdentifierType;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.MaintainIndividualBuilder;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.individual.model.IndividualRoleType;
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.MaintainOrgBuilder;
+import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.organization.model.OrgRoleType;
 import ca.bc.gov.health.qa.autotest.plr.util.ProviderType;
 import ca.bc.gov.health.qa.autotest.plr.util.UserType;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.ProviderSection;
@@ -52,6 +55,7 @@ public class UpdateProviderTests implements SimpleTest {
     public static JSONObject errorList;
 
     private static final Map<ProviderType, MaintainIndividualBuilder> defaultProviders = new HashMap<>();
+    private static MaintainOrgBuilder defaultOrg;
     private static final int MAX_DIS_ACTION_DES = 3000;
     private UpdateProviderTests() {
         try
@@ -88,6 +92,9 @@ public class UpdateProviderTests implements SimpleTest {
         MaintainIndividualBuilder defaultOOP = fhirController
                 .createIndividual(new IndividualMaintainConfig(IndividualRoleType.OOP_RECT));
         LOG.info("Created default OOP provider with IPC: {}", defaultBC.getIdentifier(IdentifierType.IPC));
+        defaultOrg = fhirController
+                .createOrganization(new OrganizationMaintainConfig(OrgRoleType.ORG));
+        LOG.info("Created default organization with IPC: {}", defaultOrg.getIdentifier(IdentifierType.IPC));
         fhirController.close();
 
         defaultProviders.put(ProviderType.BC_PRACTITIONER, defaultBC);
@@ -590,11 +597,14 @@ public class UpdateProviderTests implements SimpleTest {
     }
 
     // Update Provider - Update Work Locations
-    @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
     public void testUpdateWorkLocations(ProviderType providerType) {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
-        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        String identifier;
+        if (providerType.equals(ProviderType.ORGANIZATION)) identifier = defaultOrg.getIdentifier(IdentifierType.IPC);
+        else identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+
         UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
 
         page.addWorkLocationDataBlock("12345", true, "Test Name", "CC", "Test Info", false);
@@ -607,8 +617,29 @@ public class UpdateProviderTests implements SimpleTest {
         page.updateWorkLocationDataBlock(false, "Updated Name", "HID", "Updated Info", EndReason.CHG, false);
 
         Map<String,String> wlContent = page.grabDataBlockContent(ProviderSection.WORK_LOCATIONS, 0);
+        final String details = "Work Location Details-0-";
 
         LOG.info(wlContent);
+
+        assertEquals(wlContent.get(details+"Name"), "Updated Name",
+                "Expected updated name to be reflected in work location data block after updating work location");
+        assertEquals(wlContent.get(details+"Type"), "Health Information Distribution",
+                "Expected updated type to be reflected in work location data block after updating work location");
+        assertEquals(wlContent.get(details+"Default Flag"), "No",
+                "Expected updated default flag to be reflected in work location data block after updating work location");
+        assertEquals(wlContent.get(details+"Additional Info"), "Updated Info",
+                "Expected updated additional info to be reflected in work location data block after updating work location");
+        assertEquals(wlContent.get(details+"Effective From"), "2000-01-01",
+                "Expected updated effective from to be reflected in work location data block after updating work location");
+        assertEquals(wlContent.get(details+"Effective To"), "2999-01-01",
+                "Expected updated effective to to be reflected in work location data block after updating work location");
+
+        page.clickDataBlockUpdateButton(ProviderSection.WORK_LOCATIONS, 0);
+        page.fillWorkLocationDataBlockUpdate(true, "Test Name", "CC", "Test Info", EndReason.CHG);
+        page.clickDialogCancelButton(ProviderSection.WORK_LOCATIONS);
+
+        assertEquals(page.grabActiveDataBlockCount(ProviderSection.WORK_LOCATIONS, true), 1,
+                "Expected 1 active work location data block after cancelling update of work location");
     }
 
 	// Update Provider - Validate Provider Conditions
@@ -655,8 +686,6 @@ public class UpdateProviderTests implements SimpleTest {
                 "relationshipType");
         relationshipTypes.remove("Select One");
 
-        LOG.info(relationshipTypes);
-        LOG.info(RELATIONSHIP_TYPE_OPTIONS);
         assertTrue(relationshipTypes.containsAll(RELATIONSHIP_TYPE_OPTIONS),
                 "Expected relationship type dropdown options to contain all defined relationship types");
 

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
@@ -31,7 +31,9 @@ import ca.bc.gov.health.qa.autotest.runner.util.testng.SimpleTest;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
@@ -915,6 +917,26 @@ public class UpdateProviderTests implements SimpleTest {
 
         assertEquals(wlContent.get("Work Location Details-0-Default Flag"), "Yes",
                 "Expected 'Yes' value for default flag in work location data block when default flag checkbox is unchecked");
+
+        page.ceaseDataBlock(ProviderSection.WORK_LOCATIONS, 0);
+    }
+
+    // Update Provider - Validate Update Work Location ID
+    @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
+    public void testValidateWorkLocationIDUpdate(ProviderType providerType) {
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
+
+        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
+
+        page.addWorkLocationDataBlock(generateNumericString(15), true, "Test Name",
+                "CC", "Test Info", false);
+
+        WebElement dialog = page.clickDataBlockUpdateButton(ProviderSection.WORK_LOCATIONS, 0);
+        assertTrue(dialog.findElements(By.cssSelector("input#maintainWorkLocationForm\\:wlChid")).isEmpty(),
+                "Expected work location identifier field to be non-editable when updating work location data block");
+
+        page.clickDialogCancelButton(ProviderSection.WORK_LOCATIONS);
 
         page.ceaseDataBlock(ProviderSection.WORK_LOCATIONS, 0);
     }

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
@@ -971,6 +971,39 @@ public class UpdateProviderTests implements SimpleTest {
         }
     }
 
+    // Update Provider - Validate Update Work Location Name
+    @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
+    public void testValidateWorkLocationNameUpdate(ProviderType providerType)
+    {
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
+
+        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
+
+        page.addWorkLocationDataBlock("12345", true, "Test Name", "CC", "Test Info", false);
+
+        String error = page.updateWorkLocationDataBlock(false, generateAlphabetNumericString(256),
+                "CC", "Test Info", EndReason.CHG, true);
+
+        assertEquals(error, errorList.get("WLNameTooLong"),
+                "Expected error message for work location name exceeding max length when updating work location data block");
+
+        error = page.updateWorkLocationDataBlock(false, "", "CC", "Test Info", EndReason.CHG, true);
+
+        assertEquals(error, errorList.get("WLNameMissing"),
+                "Expected error message for missing work location name when updating work location data block");
+
+        String name = generateAlphabetNumericString(255);
+        page.updateWorkLocationDataBlock(false, name, "CC", "Test Info", EndReason.CHG, false);
+
+        Map<String,String> wlContent = page.grabDataBlockContent(ProviderSection.WORK_LOCATIONS, 0);
+
+        assertEquals(wlContent.get("Work Location Details-0-Name"), name,
+                "Expected updated name to be reflected in work location data block after updating work location with valid name");
+
+        page.ceaseDataBlock(ProviderSection.WORK_LOCATIONS, 0);
+    }
+
     // Update Provider - Validate Work Location Name
     @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
     public void testValidateWorkLocationName(ProviderType providerType)

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
@@ -19,6 +19,7 @@ import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.ProviderSection;
 import ca.bc.gov.health.qa.autotest.plr.web.pages.plr.provider.UpdateProviderPage;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.helper.UpdateSimpleHelper;
 import ca.bc.gov.health.qa.autotest.plr.web.tests.model.ConditionType;
+import ca.bc.gov.health.qa.autotest.plr.web.tests.model.EndReason;
 import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflow;
 import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflowManager;
 import ca.bc.gov.health.qa.autotest.runner.util.log.ExecutionLogManager;
@@ -586,6 +587,28 @@ public class UpdateProviderTests implements SimpleTest {
                 "Expected 1 active registry user relationship data block after adding valid registry user relationship");
 
         page.ceaseDataBlock(ProviderSection.REGISTRY_USER_RELATIONSHIPS, 0);
+    }
+
+    // Update Provider - Update Work Locations
+    @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
+    public void testUpdateWorkLocations(ProviderType providerType) {
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
+
+        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
+
+        page.addWorkLocationDataBlock("12345", true, "Test Name", "CC", "Test Info", false);
+
+        WebElement dialog = page.clickDataBlockUpdateButton(ProviderSection.WORK_LOCATIONS, 0);
+        assertTrue(dialog.isDisplayed(), "Expected work location dialog to be displayed after clicking update button on work location data block");
+
+        page.clickDialogCancelButton(ProviderSection.WORK_LOCATIONS);
+
+        page.updateWorkLocationDataBlock(false, "Updated Name", "HID", "Updated Info", EndReason.CHG, false);
+
+        Map<String,String> wlContent = page.grabDataBlockContent(ProviderSection.WORK_LOCATIONS, 0);
+
+        LOG.info(wlContent);
     }
 
 	// Update Provider - Validate Provider Conditions

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
@@ -33,7 +33,6 @@ import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
@@ -133,11 +132,7 @@ public class UpdateProviderTests implements SimpleTest {
     @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
     public void testAddProviderRelationships(ProviderType providerType)
     {
-        final MaintainIndividualBuilder otherProvider = switch (providerType) {
-            case BC_PRACTITIONER -> defaultProviders.get(ProviderType.OOP_PRACTITIONER);
-            case OOP_PRACTITIONER -> defaultProviders.get(ProviderType.BC_PRACTITIONER);
-            default -> new MaintainIndividualBuilder(); // should not occur
-        };
+        final MaintainIndividualBuilder otherProvider = getOtherProvider(defaultProviders, providerType);
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
         String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
@@ -349,8 +344,8 @@ public class UpdateProviderTests implements SimpleTest {
     
 	// Update Provider --Add Disciplinary Actions
 	@Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
-	public void testAddDisciplinaryAction(ProviderType providerType) {
-
+	public void testAddDisciplinaryAction(ProviderType providerType)
+    {
 		PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
 		String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
@@ -375,8 +370,8 @@ public class UpdateProviderTests implements SimpleTest {
 
 	//Update Provider - Validate Disciplinary Action
 	@Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
-	public void testValidateDisciplinaryAction(ProviderType providerType) {
-
+	public void testValidateDisciplinaryAction(ProviderType providerType)
+    {
 		PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
 		String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
@@ -397,8 +392,8 @@ public class UpdateProviderTests implements SimpleTest {
 	}
 	// Update Provider - Validate Disciplinary Action Description Text
 	@Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
-	public void testValidateDisciplinaryActionDescriptionText(ProviderType providerType) {
-		
+	public void testValidateDisciplinaryActionDescriptionText(ProviderType providerType)
+    {
 		String errorMsgDisActionDesLenth5003 = (String) errorList.get("errorMsgDisActionDesLenth5003");
 		String errorMsgDisActionDesLenthMissing5000 = (String) errorList.get("errorMsgDisActionDesLenthMissing5000");
 
@@ -423,8 +418,8 @@ public class UpdateProviderTests implements SimpleTest {
 
 	// Update Provider - Generating A Default Disciplinary Action ID
 	@Test(dataProvider = "practitioners",dataProviderClass = InjectableData.class)
-	public void testGeneratingDefaultDisciplinaryActionID(ProviderType providerType) {
-
+	public void testGeneratingDefaultDisciplinaryActionID(ProviderType providerType)
+    {
 		PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
 		String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
@@ -491,11 +486,7 @@ public class UpdateProviderTests implements SimpleTest {
     @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
     public void testProviderRelationshipTypes(ProviderType providerType)
     {
-        final MaintainIndividualBuilder otherProvider = switch (providerType) {
-            case BC_PRACTITIONER -> defaultProviders.get(ProviderType.OOP_PRACTITIONER);
-            case OOP_PRACTITIONER -> defaultProviders.get(ProviderType.BC_PRACTITIONER);
-            default -> new MaintainIndividualBuilder(); // should not occur
-        };
+        final MaintainIndividualBuilder otherProvider = getOtherProvider(defaultProviders, providerType);
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
         String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
@@ -525,11 +516,7 @@ public class UpdateProviderTests implements SimpleTest {
     @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
     public void testProviderRelationshipValidation(ProviderType providerType)
     {
-        final MaintainIndividualBuilder otherProvider = switch (providerType) {
-            case BC_PRACTITIONER -> defaultProviders.get(ProviderType.OOP_PRACTITIONER);
-            case OOP_PRACTITIONER -> defaultProviders.get(ProviderType.BC_PRACTITIONER);
-            default -> new MaintainIndividualBuilder(); // should not occur
-        };
+        final MaintainIndividualBuilder otherProvider = getOtherProvider(defaultProviders, providerType);
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
         String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
@@ -600,7 +587,8 @@ public class UpdateProviderTests implements SimpleTest {
 
     // Update Provider - Update Work Locations
     @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
-    public void testUpdateWorkLocations(ProviderType providerType) {
+    public void testUpdateWorkLocations(ProviderType providerType)
+    {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
         String identifier;
@@ -646,7 +634,8 @@ public class UpdateProviderTests implements SimpleTest {
 
 	// Update Provider - Validate Provider Conditions
 	@Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
-	public void testValidateProviderConditions(ProviderType providerType) {
+	public void testValidateProviderConditions(ProviderType providerType)
+    {
 		PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
 		String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
@@ -672,11 +661,7 @@ public class UpdateProviderTests implements SimpleTest {
     @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
     public void testValidateProviderRelationshipTypeCode(ProviderType providerType)
     {
-        final MaintainIndividualBuilder otherProvider = switch (providerType) {
-            case BC_PRACTITIONER -> defaultProviders.get(ProviderType.OOP_PRACTITIONER);
-            case OOP_PRACTITIONER -> defaultProviders.get(ProviderType.BC_PRACTITIONER);
-            default -> new MaintainIndividualBuilder(); // should not occur
-        };
+        final MaintainIndividualBuilder otherProvider = getOtherProvider(defaultProviders, providerType);
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
         String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
@@ -710,7 +695,8 @@ public class UpdateProviderTests implements SimpleTest {
 
     // Update Provider - Validate Related Provider ID
     @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
-    public void testValidateRelatedProviderID(ProviderType providerType) {
+    public void testValidateRelatedProviderID(ProviderType providerType)
+    {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
         String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
@@ -737,12 +723,9 @@ public class UpdateProviderTests implements SimpleTest {
 
     // Update Provider - Validate Related Provider ID and Relationship
     @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
-    public void testRelatedProviderIDAndRelationship(ProviderType providerType) {
-        final MaintainIndividualBuilder otherProvider = switch (providerType) {
-            case BC_PRACTITIONER -> defaultProviders.get(ProviderType.OOP_PRACTITIONER);
-            case OOP_PRACTITIONER -> defaultProviders.get(ProviderType.BC_PRACTITIONER);
-            default -> new MaintainIndividualBuilder(); // should not occur
-        };
+    public void testRelatedProviderIDAndRelationship(ProviderType providerType)
+    {
+        final MaintainIndividualBuilder otherProvider = getOtherProvider(defaultProviders, providerType);
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
         String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
@@ -886,6 +869,52 @@ public class UpdateProviderTests implements SimpleTest {
         page.ceaseDataBlock(ProviderSection.WORK_LOCATIONS, 0);
     }
 
+    // Update Provider - Validate Update Work Location Default Flag
+    @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
+    public void testValidateWorkLocationDefaultFlagUpdate(ProviderType providerType)
+    {
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
+
+        String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
+
+        page.addWorkLocationDataBlock("12345", false, "Test Name", "CC", "Test Info", false);
+
+        page.clickDataBlockUpdateButton(ProviderSection.WORK_LOCATIONS, 0);
+
+        assertFalse(page.isCheckBoxChecked(ProviderSection.WORK_LOCATIONS, "defaultFlag"),
+                "Expected default flag checkbox to be unchecked in work location data block when default flag is set to false");
+
+        page.clickDialogCancelButton(ProviderSection.WORK_LOCATIONS);
+
+        page.updateWorkLocationDataBlock(false, "Test Name Change", null, null, EndReason.CHG, false);
+
+        final String details = "Work Location Details-0-";
+        Map<String,String> wlContent = page.grabDataBlockContent(ProviderSection.WORK_LOCATIONS, 0);
+        assertEquals(wlContent.get(details+"Default Flag"), "No",
+                "Expected default flag to remain 'No' in work location data block after updating work location with default flag set to false");
+
+        page.clickDataBlockUpdateButton(ProviderSection.WORK_LOCATIONS, 0);
+
+        assertFalse(page.isCheckBoxChecked(ProviderSection.WORK_LOCATIONS, "defaultFlag"),
+                "Expected default flag checkbox to remain unchecked in work location data block after updating work location without changing default flag");
+
+        page.clickDialogCancelButton(ProviderSection.WORK_LOCATIONS);
+
+        page.updateWorkLocationDataBlock(true, "Test Name Change", null, null, EndReason.CHG, false);
+
+        wlContent = page.grabDataBlockContent(ProviderSection.WORK_LOCATIONS, 0);
+        assertEquals(wlContent.get(details+"Default Flag"), "Yes",
+                "Expected default flag to be 'Yes' in work location data block after updating work location with default flag set to true");
+
+        page.clickDataBlockUpdateButton(ProviderSection.WORK_LOCATIONS, 0);
+
+        assertTrue(page.isCheckBoxChecked(ProviderSection.WORK_LOCATIONS, "defaultFlag"),
+                "Expected default flag checkbox to be checked in work location data block after updating work location with default flag set to true");
+
+        page.clickDialogCancelButton(ProviderSection.WORK_LOCATIONS);
+    }
+
     // Update Provider - Validate Work Location Default Flag
     @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
     public void testValidateWorkLocationDefaultFlag(ProviderType providerType)
@@ -923,7 +952,8 @@ public class UpdateProviderTests implements SimpleTest {
 
     // Update Provider - Validate Update Work Location ID
     @Test(dataProvider = "practitioners", dataProviderClass = InjectableData.class)
-    public void testValidateWorkLocationIDUpdate(ProviderType providerType) {
+    public void testValidateWorkLocationIDUpdate(ProviderType providerType)
+    {
         PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
 
         String identifier = defaultProviders.get(providerType).getIdentifier(IdentifierType.IPC);

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/ViewProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/ViewProviderTests.java
@@ -92,7 +92,7 @@ public class ViewProviderTests implements SimpleTest
                 page.ceaseDataBlock(ProviderSection.WORK_LOCATIONS, 0);
                 page.addWorkLocationDataBlock("2", true, "Work Location", "CC", "Audit view", false);
                 page.updateWorkLocationDataBlock(true, "Corrected Work Location", "CC", null, EndReason.CORR ,false);
-                page.updateWorkLocationDataBlock(false, "Changed Work Location", "CC", "History view", EndReason.CHG, false);
+                page.updateWorkLocationDataBlock(true, "Changed Work Location", "CC", "History view", EndReason.CHG, false);
                 page.addWorkLocationDataBlock("3", true, "Second Work Location", "CC", "Current view", false);
             }
         }


### PR DESCRIPTION
This PR implements test cases related to Updating Work Location details. These are typically very similar to the Add Work Location data block test cases.

- Then Update Work Locations
- Then Validate Work Location Additional Addressee
- Then Validate Work Location Default Flag
- Then Validate Work Location ID - Updating
- Then Validate Work Location Name