### PR TITLE
Write test cases for PLR-608 Update Address - Update Block

### DIFF
--- a/autotest-plr/data/error-list.json
+++ b/autotest-plr/data/error-list.json
@@ -42,6 +42,7 @@
     "errMsg5003NoteText": "GRS.SYS.UNK.UNK.1.0.5003: Entry Error. 'Note Text' length must be between 0 and 255. Your transaction has not been processed. Correct and resubmit.",
     "errMsg5003ProviderIdentifier": "GRS.SYS.UNK.UNK.1.0.5003: Entry Error. 'Provider Identifier' length must be between 0 and 50. Your transaction has not been processed. Correct and resubmit.",
     "errMsg5003PostalCode": "GRS.SYS.ADD.UNK.1.0.5003: Entry Error. Postal Code length must be between 0 and 25. Your transaction has not been processed. Correct and resubmit.",
+    "errMsg5003Province": "GRS.SYS.UNK.UNK.1.0.5003: Entry Error. 'Province/State' length must be between 0 and 30. Your transaction has not been processed. Correct and resubmit.",
     "errMsg5004EffectiveFrom": "GRS.SYS.UNK.UNK.1.0.5004: Entry error. The following field may contain only a date: 'Effective From'. Your transaction has not been processed. Correct and resubmit.",
     "errMsg5004EffectiveTo": "GRS.SYS.UNK.UNK.1.0.5004: Entry error. The following field may contain only a date: 'Effective To'. Your transaction has not been processed. Correct and resubmit.",
     "errMsg7004NoteIdentifier": "GRS.SYS.UNK.UNK.1.0.7004: 'Note Identifier' can contain only spaces, &, ', commas, -, ., /, :, @, [, ], \\, ^, _, `, (, ), numbers, and the English alphabet.",

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -90,11 +90,14 @@ public class UpdateProviderPage extends ViewProviderPage {
 			if (title == null || title.isEmpty()) continue;
 			if (!title.contains(widgetTitlePrefix)) continue;
 
-			// regrab element (likely to have become stale) and check visibility
-			selenium_.setWaitTimeout(Duration.ofSeconds(10));
-			elem = selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.xpath(
-					"//div[@role='dialog' and @aria-hidden='false' and .//span[contains(text(),'\" + title + \"')]]")));
-			selenium_.setWaitTimeout(Duration.ofSeconds(30));
+			try {
+				// regrab element (likely to have become stale) and check visibility
+				selenium_.setWaitTimeout(Duration.ofSeconds(10));
+				elem = selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.xpath(
+						"//div[@role='dialog' and @aria-hidden='false' and .//span[contains(text(),'\" + title + \"')]]")));
+			} catch (Exception e) {
+				// TODO: handle exception
+			}
 
 			// Skip hidden/inactive dialogs
 			String ariaHidden = elem.getAttribute("aria-hidden");
@@ -109,7 +112,7 @@ public class UpdateProviderPage extends ViewProviderPage {
 	 * Clicks "Continue w/ Original" button if a validation dialog is displayed.
 	 */
 	public void handleAddressValidationDialog() {
-		waitSeconds(2); // Give UI time to render any validation dialogs
+		waitSeconds(3); // Give UI time to render any validation dialogs
 
 		// Try different dialog title prefixes that may appear
 		String[] dialogTitles = {"Address Invalid", "Address Recommended", "Validation", "Address Provided"};
@@ -129,7 +132,7 @@ public class UpdateProviderPage extends ViewProviderPage {
 					continueBtn.click();
 
 					selenium_.waitUntil(ExpectedConditions.invisibilityOf(validationWidget));
-					// waitSeconds(2);
+					waitSeconds(2);
 					return;
 				}
 			} catch (org.openqa.selenium.NoSuchElementException ignore) {
@@ -901,12 +904,12 @@ public class UpdateProviderPage extends ViewProviderPage {
 	 * @return String of error messages
 	 */
 	public String waitErrorMessage(ProviderSection section) {
-		final int MAX_ATTEMPTS = 5;
+		final int MAX_ATTEMPTS = 10;
 		int attempts = 0;
 		String msgDisplay = getDialogMessages(section);
 		while (StringUtils.isEmpty(msgDisplay)) {
 			if (attempts >= MAX_ATTEMPTS) break;
-			waitSeconds(5);
+			waitSeconds(3);
 			try {
 				msgDisplay = getDialogMessages(section);
 			} catch (StaleElementReferenceException e) {
@@ -1350,8 +1353,12 @@ public class UpdateProviderPage extends ViewProviderPage {
 		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
 		waitSeconds(2);
 
-		setDropdownListByVisibleText(ProviderSection.ADDRESSES, "addressType", addressType);
-		setDropdownListByVisibleText(ProviderSection.ADDRESSES, "addressPurpose", purpose);
+		if(addressType != null){
+			setDropdownListByVisibleText(ProviderSection.ADDRESSES, "addressType", addressType);
+		}
+		if(purpose != null){
+			setDropdownListByVisibleText(ProviderSection.ADDRESSES, "addressPurpose", purpose);
+		}
 
 		// Fill address line 1
 		String addressLine1Css = dialogCss + " >input#" + formName + "\\:addressLine1";
@@ -1382,7 +1389,7 @@ public class UpdateProviderPage extends ViewProviderPage {
 		}
 
 		// Fill city (autocomplete input) - type city and click first autocomplete result
-		if (!StringUtils.isEmpty(city)) {
+		if (city != null) {
 			String cityInputCss = "input#" + formName + "\\:city_input";
 			String cityPanelCss = "span#" + formName + "\\:city_panel";
 			WebElement cityInput = selenium_.findElement(By.cssSelector(cityInputCss));
@@ -1521,8 +1528,12 @@ public class UpdateProviderPage extends ViewProviderPage {
 		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
 		waitSeconds(2);
 
-		setDropdownListByVisibleText(ProviderSection.ADDRESSES, "addressType", addressType);
-		setDropdownListByVisibleText(ProviderSection.ADDRESSES, "addressPurpose", purpose);
+		if(addressType != null){
+			setDropdownListByVisibleText(ProviderSection.ADDRESSES, "addressType", addressType);
+		}
+		if (purpose != null) {
+			setDropdownListByVisibleText(ProviderSection.ADDRESSES, "addressPurpose", purpose);
+		}
 
 		// Fill address line 1
 		String addressLine1Css = dialogCss + " >input#" + formName + "\\:addressLine1";
@@ -1553,7 +1564,7 @@ public class UpdateProviderPage extends ViewProviderPage {
 		}
 
 		// Fill city (raw input - no autocomplete selection)
-		if (!StringUtils.isEmpty(city)) {
+		if (city != null) {
 			String cityInputCss = "input#" + formName + "\\:city_input";
 			WebElement cityInput = selenium_.findElement(By.cssSelector(cityInputCss));
 			cityInput.clear();
@@ -1645,71 +1656,113 @@ public class UpdateProviderPage extends ViewProviderPage {
 		String dialogCss = getDialogCss(ProviderSection.ADDRESSES);
 
 		clickDataBlockUpdateButton(ProviderSection.ADDRESSES, index);
-		waitSeconds(2);
+		waitSeconds(3);
 
-		// Update address line 1
-		String addressLine1Css = dialogCss + " >input#" + formName + "\\:addressLine1";
-		WebElement addressLine1Element = selenium_.findElement(By.cssSelector(addressLine1Css));
-		addressLine1Element.clear();
-		if (!StringUtils.isEmpty(addressLine1))
-			addressLine1Element.sendKeys(addressLine1);
-
-		// Update address line 2
-		String addressLine2Css = dialogCss + " >input#" + formName + "\\:addressLine2";
-		WebElement addressLine2Element = selenium_.findElement(By.cssSelector(addressLine2Css));
-		addressLine2Element.clear();
-		if (!StringUtils.isEmpty(addressLine2))
-			addressLine2Element.sendKeys(addressLine2);
-
-		// Update address line 3
-		String addressLine3Css = dialogCss + " >input#" + formName + "\\:addressLine3";
-		WebElement addressLine3Element = selenium_.findElement(By.cssSelector(addressLine3Css));
-		addressLine3Element.clear();
-		if (!StringUtils.isEmpty(addressLine3))
-			addressLine3Element.sendKeys(addressLine3);
-
-		// Update city (autocomplete input)
-		if (!StringUtils.isEmpty(city)) {
-			AutocompleteMenu cityMenu = new AutocompleteMenu(
-					selenium_,
-					By.cssSelector("input#" + formName + "\\:city_input"),
-					By.cssSelector("span#" + formName + "\\:city_panel")
-			);
-			cityMenu.fillItem(city, null);
-		}
-
-		// Update province
-		if (!StringUtils.isEmpty(province)) {
-			setDropdownListByVisibleText(ProviderSection.ADDRESSES, "province_address", province);
-		}
-
-		// Update country
-		if (!StringUtils.isEmpty(country)) {
-			setDropdownListByVisibleText(ProviderSection.ADDRESSES, "country", country);
-		}
-
-		// Update postal code
-		String postalCodeCss = dialogCss + " >input#" + formName + "\\:postalCode";
-		WebElement postalCodeElement = selenium_.findElement(By.cssSelector(postalCodeCss));
-		postalCodeElement.clear();
-		if (!StringUtils.isEmpty(postalCode))
-			postalCodeElement.sendKeys(postalCode);
+		//Only fill in the address fields that are valid for an update (address type and purpose cannot be updated, so pass in null to keep existing values)
+		fillAddressDataBlock(null, null, addressLine1, addressLine2, addressLine3,
+				city, province, country, postalCode, effectiveFrom, effectiveTo);
 
 		if (endReasonCode != null)
 			setEndReasonByVisibleText(ProviderSection.ADDRESSES, endReasonCode.getText());
 
-		setDialogEffectiveFromAndEffectiveTo(ProviderSection.ADDRESSES, effectiveFrom, effectiveTo);
-
 		clickDialogSubmitButton(ProviderSection.ADDRESSES, expectError);
-
+		
+		// Handle address validation popups that may appear (only when not expecting error)
+		handleAddressValidationDialog();
+				
 		if (expectError) {
 			msgDisplay = waitErrorMessage(ProviderSection.ADDRESSES);
-			// Cancel the dialog since it stays open after an error
-			clickDialogCancelButton(ProviderSection.ADDRESSES);
 		} else {
 			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
 		}
+
+		//Small wait as sometimes due to speed, page stalls
+        waitSeconds(3);
+
 		return msgDisplay;
+	}
+
+	/**
+	 * Attempts to update an address data block with provided values
+	 *
+	 * @param addressLine1  the first line of the address
+	 * @param addressLine2  the second line of the address (optional)
+	 * @param addressLine3  the third line of the address (optional)
+	 * @param city          the city name
+	 * @param province      the province/state code
+	 * @param country       the country code
+	 * @param postalCode    the postal code (optional)
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo   the effective to date
+	 * @param endReasonCode the end reason code
+	 * @param index         the data block index to update
+	 * @param expectError   whether an error is expected
+	 * @return the error message if expectError is true, otherwise an empty string
+	 */
+	public String updateAddressDataBlockRawCity(String addressLine1, String addressLine2, String addressLine3,
+			String city, String province, String country, String postalCode,
+			String effectiveFrom, String effectiveTo, EndReason endReasonCode, int index, boolean expectError) {
+		String msgDisplay = "";
+		String formName = DIALOG_MAP.get(ProviderSection.ADDRESSES).getFormName();
+		String dialogCss = getDialogCss(ProviderSection.ADDRESSES);
+
+		clickDataBlockUpdateButton(ProviderSection.ADDRESSES, index);
+		waitSeconds(2);
+
+		//Only fill in the address fields that are valid for an update (address type and purpose cannot be updated, so pass in null to keep existing values)
+		fillAddressDataBlockRawCity(null, null, addressLine1, addressLine2, addressLine3,
+				city, province, country, postalCode, effectiveFrom, effectiveTo);
+
+		if (endReasonCode != null)
+			setEndReasonByVisibleText(ProviderSection.ADDRESSES, endReasonCode.getText());
+
+		clickDialogSubmitButton(ProviderSection.ADDRESSES, expectError);
+		
+				
+		if (expectError) {
+			msgDisplay = waitErrorMessage(ProviderSection.ADDRESSES);
+		} else {
+			// Handle address validation popups that may appear
+			handleAddressValidationDialog();
+			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		}
+
+		//Small wait as sometimes due to speed, page stalls
+        waitSeconds(2);
+
+		return msgDisplay;
+	}
+
+	/**
+	 * Attempts to update an address data block with provided values
+	 *
+	 * @param addressLine1  the first line of the address
+	 * @param addressLine2  the second line of the address (optional)
+	 * @param addressLine3  the third line of the address (optional)
+	 * @param city          the city name
+	 * @param province      the province/state code
+	 * @param country       the country code
+	 * @param postalCode    the postal code (optional)
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo   the effective to date
+	 * @param endReasonCode the end reason code
+	 * @param index         the data block index to update
+	 */
+	public void updateCancelAddressDataBlock(String addressLine1, String addressLine2, String addressLine3,
+			String city, String province, String country, String postalCode,
+			String effectiveFrom, String effectiveTo, EndReason endReasonCode, int index) {
+
+		clickDataBlockUpdateButton(ProviderSection.ADDRESSES, index);
+		waitSeconds(2);
+
+		//Only fill in the address fields that are valid for an update (address type and purpose cannot be updated, so pass in null to keep existing values)
+		fillAddressDataBlock(null, null, addressLine1, addressLine2, addressLine3,
+				city, province, country, postalCode, effectiveFrom, effectiveTo);
+
+		if (endReasonCode != null)
+			setEndReasonByVisibleText(ProviderSection.ADDRESSES, endReasonCode.getText());
+
+		clickDialogCancelButton(ProviderSection.ADDRESSES);
 	}
 
 	/**
@@ -1796,7 +1849,6 @@ public class UpdateProviderPage extends ViewProviderPage {
 			msgDisplay = waitErrorMessage(ProviderSection.TELECOMMUNICATIONS);
 		} else {
 			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
-			clickDialogCancelButton(ProviderSection.TELECOMMUNICATIONS); // Cancel to close the dialog after successful add
 		}
 		return msgDisplay;
 	}
@@ -1879,8 +1931,6 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 		if (expectError) {
 			msgDisplay = waitErrorMessage(ProviderSection.TELECOMMUNICATIONS);
-			// Cancel the dialog since it stays open after an error
-			clickDialogCancelButton(ProviderSection.TELECOMMUNICATIONS);
 		} else {
 			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
 		}

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderTests.java
@@ -9,6 +9,7 @@ import ca.bc.gov.health.qa.autotest.core.util.config.Config;
 import ca.bc.gov.health.qa.autotest.core.util.config.ConfigProvider;
 import ca.bc.gov.health.qa.autotest.plr.data.InjectableData;
 import ca.bc.gov.health.qa.autotest.plr.fhir.FHIRController;
+import ca.bc.gov.health.qa.autotest.plr.fhir.data.individual.IndividualDataGenerator;
 import ca.bc.gov.health.qa.autotest.plr.fhir.data.individual.IndividualMaintainConfig;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.MaintainRequestBuilder;
 import ca.bc.gov.health.qa.autotest.plr.fhir.maintain.common.model.IdentifierType;
@@ -61,6 +62,7 @@ public class UpdateProviderTests implements SimpleTest {
     public static JSONObject errorList;
 
     private static final Map<ProviderType, MaintainRequestBuilder> defaultProviders = new LinkedHashMap<>();
+    private static IndividualDataGenerator individualDataGenerator = IndividualDataGenerator.getInstance();
     private static MaintainOrgBuilder defaultOrg;
     private static final int MAX_DIS_ACTION_DES = 3000;
     private UpdateProviderTests() {
@@ -2041,7 +2043,7 @@ public class UpdateProviderTests implements SimpleTest {
         assertEquals(error, errorList.get("errMsg7009"),
                 "Expected error for invalid Canadian postal code format");
 
-        // Enter address with country as Canada - postal code exceeding 25 characters - failure
+        // Enter address with country not as Canada - postal code exceeding 25 characters - failure
         purposeCode = page.getAvailablePurposeCodeForAddressType(AddressType.M.getCode());
         error = page.addAddressDataBlock(
                 AddressType.M.getText(),
@@ -2329,6 +2331,246 @@ public class UpdateProviderTests implements SimpleTest {
         }
 
    }
+
+    // Update Provider - Update block - General Address Validation
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testGeneralAddressValidationUpdate(ProviderType providerType) {
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
+
+        int addressIndex = 0;
+
+        //[line1, city, postal]
+        String[] validAddress = individualDataGenerator.generateAddress();
+
+        // 1. Update address with address line 1 only (should succeed)
+        page.updateAddressDataBlock(
+            validAddress[0], null, null, validAddress[1], "BC - British Columbia", "CA - CANADA", validAddress[2],
+            effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, false);
+        LinkedHashMap<String, String> content = page.grabDataBlockContent(ProviderSection.ADDRESSES, addressIndex);
+        assertEquals(content.get("Address Line 1"), validAddress[0], "Address Line 1 should be updated");
+        assertTrue(content.get("City").contains(validAddress[1]), "City should be updated");
+        assertEquals(content.get("State/Prov"), "BC", "Province should be updated");
+        assertEquals(content.get("Country"), "CANADA (CA)", "Country should be updated");
+        assertEquals(content.get("Postal/Zip Code"), validAddress[2], "Postal Code should be updated");
+
+        // 2. Update address with address line 2 only, line 1 null (should fail)
+        String error = page.updateAddressDataBlock(
+            null, validAddress[0], null, validAddress[1], "BC - British Columbia", "CA - CANADA", validAddress[2],
+            effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, true);
+        assertEquals(error, errorList.get("missingAddressLine1"), "Expected error for missing address line 1");
+
+        // 3. Update address line 1 with a space between numbers "456 789 Main St" (should succeed)
+        page.updateAddressDataBlock(
+            "456 789 Main St", null, null, "Vancouver", "BC - British Columbia", "CA - CANADA", "V6B 1A1",
+            effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, false);
+        content = page.grabDataBlockContent(ProviderSection.ADDRESSES, addressIndex);
+        assertEquals(content.get("Address Line 1"), "456 789 Main St", "Address Line 1 should be updated");
+
+        // 4. Update address line 1 with Postal office information included "PO Box 1234 Station Main" (should succeed)
+        page.updateAddressDataBlock(
+            "PO Box 1234 Station Main", null, null, "Vancouver", "BC - British Columbia", "CA - CANADA", "V6B 1A1",
+            effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, false);
+        content = page.grabDataBlockContent(ProviderSection.ADDRESSES, addressIndex);
+        assertEquals(content.get("Address Line 1"), "PO Box 1234 Station Main", "Address Line 1 should be updated");
+
+        // 5. Update address with st type abbreviation (should succeed)
+        page.updateAddressDataBlock(
+            "789 Oak Ave", null, null, "Vancouver", "BC - British Columbia", "CA - CANADA", "V6B 1A1",
+            effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, false);
+        content = page.grabDataBlockContent(ProviderSection.ADDRESSES, addressIndex);
+        assertEquals(content.get("Address Line 1"), "789 Oak Ave", "Address Line 1 should be updated");
+   }
+
+   // Update Provider - Update block - Validate Postal Code
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidatePostalCodeUpdate(ProviderType providerType) {
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
+
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
+
+        int addressIndex = 0;
+        String[] validAddress = individualDataGenerator.generateAddress();
+
+        // Update address with country as Canada - postal code with invalid format - failure
+        String error = page.updateAddressDataBlock(
+            validAddress[0], null, null, validAddress[1], "BC - British Columbia", "CA - CANADA", "INVALID",
+            effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, true);
+        assertEquals(error, errorList.get("errMsg7009"), "Expected error for invalid Canadian postal code format");
+
+        // Update address with country not as Canada - postal code exceeding 25 characters - failure
+        error = page.updateAddressDataBlock(
+            validAddress[0], null, null, validAddress[1], "Sao Paulo", "BR - BRAZIL", generateAlphabetNumericString(26),
+            effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, true);
+        assertEquals(error, errorList.get("errMsg5003PostalCode"), "Expected error for postal code exceeding 25 characters (country not Canada)");
+
+    }
+
+    // Update Provider - Update block - Validate Address Line One
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateAddressLineOneUpdatePartOne(ProviderType providerType) {
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
+
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
+
+        int addressIndex = 0;
+        String[] validAddress = individualDataGenerator.generateAddress();
+
+        // Enter address with line 1 exceeding 101 characters - fail
+        String error = page.updateAddressDataBlock(
+            generateAlphabetNumericString(101), null, null, validAddress[1], "BC - British Columbia", "CA - CANADA", validAddress[2],
+            effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, true);
+        assertEquals(error, errorList.get("addressLine1TooLong"), "Expected error for address line 1 exceeding 101 characters");
+
+        LinkedHashMap<String, String> content = page.grabDataBlockContent(ProviderSection.ADDRESSES, addressIndex);
+
+        // Enter address with line 1 blank - fail
+        error = page.updateAddressDataBlock(
+            null, null, null, validAddress[1], "BC - British Columbia", "CA - CANADA", validAddress[2],
+            effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, true);
+        assertEquals(error, errorList.get("missingAddressLine1"), "Expected error for blank address line 1");
+
+    }
+
+     // Update Provider - Update block - Validate Address Line One
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateAddressLineOneUpdatePartTwo(ProviderType providerType) {
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
+
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
+
+        int addressIndex = 0;
+        String[] validAddress = individualDataGenerator.generateAddress();
+
+        // Enter address with line 1 as "NO FIXED ADDRESS" - Success
+        page.updateAddressDataBlock(
+            "NO FIXED ADDRESS", null, null, validAddress[1], "BC - British Columbia", "CA - CANADA", validAddress[2],
+            effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, false);
+        LinkedHashMap<String, String> content = page.grabDataBlockContent(ProviderSection.ADDRESSES, addressIndex);
+        assertEquals(content.get("Address Line 1"), "NO FIXED ADDRESS", "Address Line 1 should be updated");
+
+        // Enter address with line 1 as "UNKNOWN" - Success
+        page.updateAddressDataBlock(
+            "UNKNOWN", null, null, validAddress[1], "BC - British Columbia", "CA - CANADA", validAddress[2],
+            effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, false);
+        content = page.grabDataBlockContent(ProviderSection.ADDRESSES, addressIndex);
+        assertEquals(content.get("Address Line 1"), "UNKNOWN", "Address Line 1 should be updated");
+
+        // Enter address line 1 as "NA" - Success
+        page.updateAddressDataBlock(
+            "NA", null, null, validAddress[1], "BC - British Columbia", "CA - CANADA", validAddress[2],
+            effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, false);
+        content = page.grabDataBlockContent(ProviderSection.ADDRESSES, addressIndex);
+        assertEquals(content.get("Address Line 1"), "NA", "Address Line 1 should be updated");
+    }
+
+    // Update Provider - Update block - Update Addresses
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testUpdateAddresses(ProviderType providerType) {
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
+
+        // Update valid address block
+        int addressIndex = 0;
+        String[] validAddress = individualDataGenerator.generateAddress();
+        String[] secondValidAddress = individualDataGenerator.generateAddress();
+
+        page.updateAddressDataBlock(
+            validAddress[0], null, null, validAddress[1], "BC - British Columbia", "CA - CANADA", validAddress[2],
+            effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, false);
+
+        LinkedHashMap<String, String> content = page.grabDataBlockContent(ProviderSection.ADDRESSES, addressIndex);
+        assertEquals(content.get("Address Line 1"), validAddress[0], "Address Line 1 should be updated");
+        assertTrue(content.get("City").contains(validAddress[1]), "City should be updated");
+        assertEquals(content.get("State/Prov"), "BC", "Province should be updated");
+        assertEquals(content.get("Country"), "CANADA (CA)", "Country should be updated");
+        assertEquals(content.get("Postal/Zip Code"), validAddress[2], "Postal Code should be updated");
+        
+        // Open dialog to update address block and cancel. Check address was not updated.
+        page.updateCancelAddressDataBlock(
+            secondValidAddress[0], null, null, secondValidAddress[1], "BC - British Columbia", "CA - CANADA", secondValidAddress[2],
+            effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex);
+
+
+        // After cancel, the address block should remain unchanged
+        LinkedHashMap<String, String> afterCancelContent = page.grabDataBlockContent(ProviderSection.ADDRESSES, addressIndex);
+        assertEquals(afterCancelContent.get("Address Line 1"), content.get("Address Line 1"), "Address Line 1 should remain unchanged after cancel");
+        assertTrue(afterCancelContent.get("City").contains(content.get("City")), "City should remain unchanged after cancel");
+        assertEquals(afterCancelContent.get("State/Prov"), content.get("State/Prov"), "Province should remain unchanged after cancel");
+        assertEquals(afterCancelContent.get("Country"), content.get("Country"), "Country should remain unchanged after cancel");
+        assertEquals(afterCancelContent.get("Postal/Zip Code"), content.get("Postal/Zip Code"), "Postal Code should remain unchanged after cancel");
+    }
+
+    // Update Provider - Update block - Validate City
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateCityUpdate(ProviderType providerType) {
+
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
+
+        int addressIndex = 0;
+        String[] validAddress = individualDataGenerator.generateAddress();
+
+        // Update address with city blank - should fail
+        String error = page.updateAddressDataBlockRawCity(
+            validAddress[0], null, null, "", "BC - British Columbia", "CA - CANADA", validAddress[2],
+            effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, true);
+        assertEquals(error, errorList.get("missingCity"), "Expected error for missing city");
+
+        // Update address with city exceeding 60 characters - should fail (use raw city to skip autocomplete)
+        error = page.updateAddressDataBlockRawCity(
+            validAddress[0], null, null, generateAlphabetNumericString(61), "BC - British Columbia", "CA - CANADA", validAddress[2],
+            effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, true);
+        assertEquals(error, errorList.get("cityTooLong"), "Expected error for city exceeding 60 characters");
+
+        // Update address with city = 60 characters - should succeed (use raw city to skip autocomplete)
+        String city60 = generateAlphabetNumericString(60);
+        page.updateAddressDataBlockRawCity(
+                validAddress[0], null, null, city60, "BC - British Columbia", "CA - CANADA", validAddress[2],
+                effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, false);
+        LinkedHashMap<String, String> content = page.grabDataBlockContent(ProviderSection.ADDRESSES, addressIndex);
+        assertEquals(content.get("City"), city60, "City should be updated to 60 character value");
+
+    }
+
+    // Update Provider - Update block - Validate Province
+    @Test(dataProvider = "allProviderTypes", dataProviderClass = InjectableData.class)
+    public void testValidateProvinceUpdate(ProviderType providerType) {
+
+        PlrWebWorkflow workflow = workflowManager_.selectWorkflow(UserType.ADMIN);
+        String identifier = getIdentifierFromBuilder(defaultProviders, providerType);
+        UpdateProviderPage page = viewByIdentifierAsUpdateProvider(identifier, workflowManager_);
+
+        int addressIndex = 0;
+        String[] validAddress = individualDataGenerator.generateAddress();
+
+        //In the address update screen, select a country that is not Canada or the US, leave province empty - failure
+        String nonCaUsCountry = "BR - BRAZIL";
+        String nonCaUsCountryShort = "BRAZIL (BR)";
+        String provinceEmpty = null;
+
+        // 1. Province > 30 chars, country not CA/US - should fail
+        String provinceTooLong = generateAlphabetNumericString(31);
+        String error = page.updateAddressDataBlock(
+                validAddress[0], null, null, validAddress[1], provinceTooLong, nonCaUsCountry, validAddress[2],
+                effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, true);
+        assertEquals(error, errorList.get("errMsg5003Province"), "Expected error for province exceeding 30 characters when country is not Canada/US");
+
+        // 2. Province = 30 chars - should succeed
+        String provinceMax = generateAlphabetNumericString(30);
+        page.updateAddressDataBlock(
+                validAddress[0], null, null, validAddress[1], provinceMax, nonCaUsCountry, validAddress[2],
+                effective_date(), increment_year_for_effective_date(), EndReason.CHG, addressIndex, false);
+        LinkedHashMap<String, String> content = page.grabDataBlockContent(ProviderSection.ADDRESSES, addressIndex);
+        assertEquals(content.get("State/Prov"), provinceMax, "Province should be updated to 30 character value for non-Canada/US country");
+
+    }
 
     /**
      * Tries to wait some number of seconds. Will fail the test used in if interrupted.


### PR DESCRIPTION
Test cases of PLR 608 that are address related:
Note the following points - 
- Note that all the new tests have appended an "Update" at the end to be differentiated to the add block tests
- Validate Province and State Address codes with country - covered by other tests
- Validate Address Purpose Code - Do not apply for Update
- Validate Address Type Code - Do not apply for Update

For testValidateAddressLineOne - This test was split in 2 because it will sometimes become stall, I have the impression that there seems to be an issue when cancelling an update to an address after an error and then entering back again the dialog to update. I would mention this to Varughese the above error also happens quite frequently with Validate Province. If you have any questions or can find a solution to this, that would be appreciated. Thank you!

