### PR TITLE
Feature/plr 608 3 - Implement Validate Communication Purpose Type code

### DIFF
--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -796,6 +796,33 @@ public class UpdateProviderPage extends ViewProviderPage {
 		return msgDisplay;
 	}
 
+	public String addWLAddressDataBlock(int wlIndex, String addressType, String purpose,
+										String addressLine1, String addressLine2, String addressLine3,
+										String city, String province, String postalCode, String country,
+										String effectiveFrom, String effectiveTo, boolean expectError)
+	{
+		String msgDisplay = "";
+		String dialogCss = getDialogCss(ProviderSection.ADDRESSES);
+
+		clickWLHeaderAddButton(ProviderSection.ADDRESSES, wlIndex);
+
+		fillAddressDataBlock(addressType, purpose, addressLine1, addressLine2, addressLine3, city, province, country,
+								postalCode, effectiveFrom, effectiveTo);
+
+		clickDialogSubmitButton(ProviderSection.ADDRESSES, expectError);
+
+		// Handle address validation popups that may appear (only when not expecting error)
+		handleAddressValidationDialog();
+
+		if (expectError) {
+			// Wait for error message (waitErrorMessage already clicks Cancel when done)
+			msgDisplay = waitErrorMessage(ProviderSection.ADDRESSES);
+		} else {
+			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		}
+		return msgDisplay;
+	}
+
 	/**
 	 * performing action of updating Work Location Data Block, perform error message check if necessary
 	 * @param defaultFlag the default flag to indicate whether to check the default flag checkbox

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -892,6 +892,66 @@ public class UpdateProviderPage extends ViewProviderPage {
 	}
 
 	/**
+	 * performing action of adding Work Location Telecom Data Block, perform error message check if necessary
+	 * @param wlIndex the index of work location to add the telecom data block for
+	 * @param telecomType the telecom type to select
+	 * @param purpose the purpose to select
+	 * @param areaCode the area code to input
+	 * @param number the number to input
+	 * @param extension the extension to input
+	 * @param effectiveFrom the effective from date to input
+	 * @param effectiveTo the effective to date to input
+	 * @param expectError if this action expect returning error messages
+	 * @return expected error message or empty string if no error message expected
+	 */
+	public String addWLTelecomDataBlock(int wlIndex, String telecomType, String purpose, String areaCode, String number, String extension,
+										String effectiveFrom, String effectiveTo, boolean expectError)
+	{
+		String msgDisplay = "";
+		String dialogCss = getDialogCss(ProviderSection.TELECOMMUNICATIONS);
+
+		clickWLHeaderAddButton(ProviderSection.TELECOMMUNICATIONS, wlIndex);
+
+		fillTelecommunicationDataBlock(telecomType, purpose, areaCode, number, extension, effectiveFrom, effectiveTo);
+
+		clickDialogSubmitButton(ProviderSection.TELECOMMUNICATIONS, expectError);
+
+		if (expectError) msgDisplay = waitErrorMessage(ProviderSection.TELECOMMUNICATIONS);
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return msgDisplay;
+	}
+
+	/**
+	 * performing action of adding Work Location Electronic Address Data Block, perform error message check if necessary
+	 * @param wlIndex the index of work location to add the electronic address data block for
+	 * @param eAddressType the electronic address type to select
+	 * @param purpose the purpose to select
+	 * @param address the electronic address to input
+	 * @param effectiveFrom the effective from date to input
+	 * @param effectiveTo the effective to date to input
+	 * @param expectError if this action expect returning error messages
+	 * @return expected error message or empty string if no error message expected
+	 */
+	public String addWLElecAddressDataBlock(int wlIndex, String eAddressType, String purpose, String address,
+										String effectiveFrom, String effectiveTo, boolean expectError)
+	{
+		String msgDisplay = "";
+		String dialogCss = getDialogCss(ProviderSection.ELECTRONIC_ADDRESSES);
+
+		clickWLHeaderAddButton(ProviderSection.ELECTRONIC_ADDRESSES, wlIndex);
+
+		fillElectronicAddressDataBlock(eAddressType, purpose, address, effectiveFrom, effectiveTo);
+
+		clickDialogSubmitButton(ProviderSection.ELECTRONIC_ADDRESSES, expectError);
+
+		if (expectError) msgDisplay = waitErrorMessage(ProviderSection.ELECTRONIC_ADDRESSES);
+
+		selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return msgDisplay;
+	}
+
+	/**
 	 * performing action of updating Work Location Address Data Block, perform error message check if necessary
 	 * @param wlIndex the index of work location to update the address data block for
 	 * @param entityIndex the index of the address data block within the work location to update
@@ -934,6 +994,43 @@ public class UpdateProviderPage extends ViewProviderPage {
 		if (expectError) {
 			// Wait for error message (waitErrorMessage already clicks Cancel when done)
 			msgDisplay = waitErrorMessage(ProviderSection.ADDRESSES);
+		} else {
+			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		}
+		return msgDisplay;
+	}
+
+	/**
+	 * performing action of updating Work Location Telecom Data Block, perform error message check if necessary
+	 * @param wlIndex the index of work location to update the telecom data block for
+	 * @param entityIndex the index of the telecom data block within the work location to update
+	 * @param areaCode the area code to input
+	 * @param number the number to input
+	 * @param extension the extension to input
+	 * @param effectiveFrom the effective from date to input
+	 * @param effectiveTo the effective to date to input
+	 * @param endReason the end reason to select
+	 * @param expectError if this action expect returning error messages
+	 * @return expected error message or empty string if no error message expected
+	 */
+	public String updateWLTelecomDataBlock(int wlIndex, int entityIndex, String areaCode, String number, String extension,
+										String effectiveFrom, String effectiveTo, EndReason endReason, boolean expectError)
+	{
+		String msgDisplay = "";
+		String dialogCss = getDialogCss(ProviderSection.TELECOMMUNICATIONS);
+
+		clickWLHeaderUpdateButton(ProviderSection.TELECOMMUNICATIONS, wlIndex, entityIndex);
+
+		fillTelecommunicationDataBlock(null, null, areaCode, number, extension, effectiveFrom, effectiveTo);
+
+		if (endReason != null) {
+			setEndReasonByVisibleText(ProviderSection.TELECOMMUNICATIONS, endReason.getText());
+		}
+
+		clickDialogSubmitButton(ProviderSection.TELECOMMUNICATIONS, expectError);
+
+		if (expectError) {
+			msgDisplay = waitErrorMessage(ProviderSection.TELECOMMUNICATIONS);
 		} else {
 			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
 		}
@@ -1977,15 +2074,19 @@ public class UpdateProviderPage extends ViewProviderPage {
 		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
 		waitSeconds(2);
 
-		setDropdownListByVisibleText(ProviderSection.TELECOMMUNICATIONS, "telecomType", telecomType);
-		waitSeconds(1); // Wait for AJAX update after dropdown selection
+		if (telecomType != null) {
+			setDropdownListByVisibleText(ProviderSection.TELECOMMUNICATIONS, "telecomType", telecomType);
+			waitSeconds(1); // Wait for AJAX update after dropdown selection
+		}
 
 		// Organizations use "telecomPurposeFiltered", practitioners use "telecomPurpose"
-		String purposePanelCss = "div#" + formName + "\\:telecomPurposeFiltered_panel";
-		if (!selenium_.findElements(By.cssSelector(purposePanelCss)).isEmpty()) {
-			setDropdownListByVisibleText(ProviderSection.TELECOMMUNICATIONS, "telecomPurposeFiltered", purpose);
-		} else {
-			setDropdownListByVisibleText(ProviderSection.TELECOMMUNICATIONS, "telecomPurpose", purpose);
+		if (purpose != null) {
+			String purposePanelCss = "div#" + formName + "\\:telecomPurposeFiltered_panel";
+			if (!selenium_.findElements(By.cssSelector(purposePanelCss)).isEmpty()) {
+				setDropdownListByVisibleText(ProviderSection.TELECOMMUNICATIONS, "telecomPurposeFiltered", purpose);
+			} else {
+				setDropdownListByVisibleText(ProviderSection.TELECOMMUNICATIONS, "telecomPurpose", purpose);
+			}
 		}
 
 		// Fill area code

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -366,6 +366,48 @@ public class UpdateProviderPage extends ViewProviderPage {
 		return selenium_.findElementByCss(dialogCss);
 	}
 
+	public WebElement clickWLHeaderUpdateButton(ProviderSection section, int wlIndex, int entityIndex) {
+		// expand the work location if hasn't happened yet
+		expandDataBlock(ProviderSection.WORK_LOCATIONS, wlIndex, true);
+
+		final String panelType = switch (section) {
+			case ProviderSection.ADDRESSES -> "wlAddressPanel";
+			case ProviderSection.TELECOMMUNICATIONS -> "telecommunicationPanel";
+			case ProviderSection.ELECTRONIC_ADDRESSES -> "eAddressPanel";
+			case ProviderSection.COMMUNICATION_PREFERENCE -> "informationRoutePanel";
+			default -> throw new IllegalArgumentException("Section " + section + " is not supported for updating within Work Locations");
+		};
+
+		final String wlRepeatId = String.format("wlRepeat\\:%d\\:", wlIndex);
+		final String wlPanelId = String.format("\\:%d\\:%s", entityIndex, panelType);
+
+		String clickElementCss = getSectionSelector(ProviderSection.WORK_LOCATIONS) + " > div > table > tbody > tr > td > div#";
+		clickElementCss += wlRepeatId + "workLocationPanel > div > div > div > div#" + wlRepeatId;
+		switch (section) {
+			case ProviderSection.ADDRESSES -> clickElementCss += "workLocationAddressesPanel";
+			case ProviderSection.TELECOMMUNICATIONS -> clickElementCss += "workLocationTelecommunicationsPanel";
+			case ProviderSection.ELECTRONIC_ADDRESSES -> clickElementCss += "workLocationElectronicAddressesPanel";
+			case ProviderSection.COMMUNICATION_PREFERENCE -> clickElementCss += "workLocationInformationRoutesPanel";
+			default -> throw new IllegalArgumentException("Section " + section + " is not supported for updating within Work Locations");
+		}
+		clickElementCss += " > div > table > tbody > tr > td > div[id^='" + wlRepeatId + "'][id*='" + wlPanelId + "'] > div > div > a > img[title^='Update']";
+
+		selenium_.waitUntil(ExpectedConditions.elementToBeClickable(By.cssSelector(clickElementCss)));
+		WebElement updateButton = selenium_.findElementByCss(clickElementCss);
+		selenium_.scrollIntoView(updateButton);
+
+		try {
+			updateButton.click();
+		} catch (StaleElementReferenceException e) {
+			waitSeconds(2);
+			updateButton.click();
+		}
+		String dialogCss = getDialogCss(section);
+		WebElement visibleElement = selenium_
+				.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return selenium_.findElementByCss(dialogCss);
+	}
+
 	/**
 	 * Get Dialog Css selector
 	 *
@@ -796,6 +838,23 @@ public class UpdateProviderPage extends ViewProviderPage {
 		return msgDisplay;
 	}
 
+	/**
+	 * performing action of adding Work Location Address Data Block, perform error message check if necessary
+	 * @param wlIndex the index of work location to add the address data block for
+	 * @param addressType the address type to select
+	 * @param purpose the purpose to select
+	 * @param addressLine1 the address line 1 to input
+	 * @param addressLine2 the address line 2 to input
+	 * @param addressLine3 the address line 3 to input
+	 * @param city the city to input
+	 * @param province the province to input
+	 * @param postalCode the postal code to input
+	 * @param country the country to select
+	 * @param effectiveFrom the effective from date to input
+	 * @param effectiveTo the effective to date to input
+	 * @param expectError if this action expect returning error messages
+	 * @return expected error message or empty string if no error message expected
+	 */
 	public String addWLAddressDataBlock(int wlIndex, String addressType, String purpose,
 										String addressLine1, String addressLine2, String addressLine3,
 										String city, String province, String postalCode, String country,
@@ -808,6 +867,38 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 		fillAddressDataBlock(addressType, purpose, addressLine1, addressLine2, addressLine3, city, province, country,
 								postalCode, effectiveFrom, effectiveTo);
+
+		clickDialogSubmitButton(ProviderSection.ADDRESSES, expectError);
+
+		// Handle address validation popups that may appear (only when not expecting error)
+		handleAddressValidationDialog();
+
+		if (expectError) {
+			// Wait for error message (waitErrorMessage already clicks Cancel when done)
+			msgDisplay = waitErrorMessage(ProviderSection.ADDRESSES);
+		} else {
+			selenium_.waitUntil(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(dialogCss)));
+		}
+		return msgDisplay;
+	}
+
+	public String updateWLAddressDataBlock(int wlIndex, int entityIndex, String addressType, String purpose,
+									   String addressLine1, String addressLine2, String addressLine3,
+									   String city, String province, String postalCode, String country,
+									   String effectiveFrom, String effectiveTo, EndReason endReason,
+									   boolean expectError)
+	{
+		String msgDisplay = "";
+		String dialogCss = getDialogCss(ProviderSection.ADDRESSES);
+
+		clickWLHeaderUpdateButton(ProviderSection.ADDRESSES, wlIndex, entityIndex);
+
+		fillAddressDataBlock(addressType, purpose, addressLine1, addressLine2, addressLine3, city, province, country,
+				postalCode, effectiveFrom, effectiveTo);
+
+		if (endReason != null) {
+			setEndReasonByVisibleText(ProviderSection.ADDRESSES, endReason.getText());
+		}
 
 		clickDialogSubmitButton(ProviderSection.ADDRESSES, expectError);
 

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -366,6 +366,15 @@ public class UpdateProviderPage extends ViewProviderPage {
 		return selenium_.findElementByCss(dialogCss);
 	}
 
+	/**
+	 * Clicks the update button on a specified data block within a work location section
+	 * (Addresses, Electronic Addresses, Telecommunications, Communication Preferences)
+	 * @param section the provider section within the work location to find the update button
+	 *                   will only accept Addresses, Electronic Addresses, Telecommunications, and Communication Preferences
+	 * @param wlIndex the index of the work location to find the data block's update button within
+	 * @param entityIndex the index of the data block within the work location to find and click the update button for
+	 * @return the WebElement of the dialog content after clicking the update button and waiting for the dialog to be visible
+	 */
 	public WebElement clickWLHeaderUpdateButton(ProviderSection section, int wlIndex, int entityIndex) {
 		// expand the work location if hasn't happened yet
 		expandDataBlock(ProviderSection.WORK_LOCATIONS, wlIndex, true);
@@ -882,7 +891,7 @@ public class UpdateProviderPage extends ViewProviderPage {
 		return msgDisplay;
 	}
 
-	public String updateWLAddressDataBlock(int wlIndex, int entityIndex, String addressType, String purpose,
+	public String updateWLAddressDataBlock(int wlIndex, int entityIndex,
 									   String addressLine1, String addressLine2, String addressLine3,
 									   String city, String province, String postalCode, String country,
 									   String effectiveFrom, String effectiveTo, EndReason endReason,
@@ -893,8 +902,8 @@ public class UpdateProviderPage extends ViewProviderPage {
 
 		clickWLHeaderUpdateButton(ProviderSection.ADDRESSES, wlIndex, entityIndex);
 
-		fillAddressDataBlock(addressType, purpose, addressLine1, addressLine2, addressLine3, city, province, country,
-				postalCode, effectiveFrom, effectiveTo);
+		fillAddressDataBlock(null, null, addressLine1, addressLine2, addressLine3,
+				city, province, country, postalCode, effectiveFrom, effectiveTo);
 
 		if (endReason != null) {
 			setEndReasonByVisibleText(ProviderSection.ADDRESSES, endReason.getText());

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -297,6 +297,45 @@ public class UpdateProviderPage extends ViewProviderPage {
 		return selenium_.findElementByCss(dialogCss);
 	}
 
+	/**
+	 * Clicks the add button in the header of a work location
+	 * @param section the provider section within the work location
+	 *                will only accept Addresses, Electronic Addresses, Telecommunications, and Communication Preferences
+	 * @param index   the index of work location to add the data block for
+	 * @return the WebElement of the dialog content after clicking the add button and waiting for the dialog to be visible
+	 */
+	public WebElement clickWLHeaderAddButton(ProviderSection section, int index)
+	{
+		// expand the work location if hasn't happened yet
+		expandDataBlock(ProviderSection.WORK_LOCATIONS, index, true);
+
+		String clickElementCss = getSectionSelector(ProviderSection.WORK_LOCATIONS) + " > div > table > tbody > tr > td > ";
+		clickElementCss += String.format("div#wlRepeat\\:%d\\:workLocationPanel > div > div > div > div#wlRepeat\\:%d\\:", index, index);
+		switch (section) {
+			case ProviderSection.ADDRESSES -> clickElementCss += "workLocationAddressesPanel";
+			case ProviderSection.TELECOMMUNICATIONS -> clickElementCss += "workLocationTelecommunicationsPanel";
+			case ProviderSection.ELECTRONIC_ADDRESSES -> clickElementCss += "workLocationElectronicAddressesPanel";
+			case ProviderSection.COMMUNICATION_PREFERENCE -> clickElementCss += "workLocationInformationRoutesPanel";
+			default -> throw new IllegalArgumentException("Section " + section + " is not supported for adding within Work Locations");
+		}
+		clickElementCss += " > div > div > a > img[title='" + DIALOG_MAP.get(section).getAddButtonImgText() + "']";
+
+		selenium_.waitUntil(ExpectedConditions.elementToBeClickable(By.cssSelector(clickElementCss)));
+		WebElement clickElement = selenium_.findElement(By.cssSelector(clickElementCss));
+		selenium_.scrollIntoView(clickElement);
+		try {
+			clickElement.click();
+		} catch (StaleElementReferenceException | ElementClickInterceptedException e) {
+			waitSeconds(2);
+			clickElement = selenium_.findElement(By.cssSelector(clickElementCss));
+			clickElement.click();
+		}
+
+		String dialogCss = getDialogCss(section);
+		selenium_.waitUntil(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(dialogCss)));
+		return selenium_.findElementByCss(dialogCss);
+	}
+
     /**
      * Attempts to click the update button on a specified data block
      *

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/pages/plr/provider/UpdateProviderPage.java
@@ -891,6 +891,23 @@ public class UpdateProviderPage extends ViewProviderPage {
 		return msgDisplay;
 	}
 
+	/**
+	 * performing action of updating Work Location Address Data Block, perform error message check if necessary
+	 * @param wlIndex the index of work location to update the address data block for
+	 * @param entityIndex the index of the address data block within the work location to update
+	 * @param addressLine1 the address line 1 to input
+	 * @param addressLine2 the address line 2 to input
+	 * @param addressLine3 the address line 3 to input
+	 * @param city the city to input
+	 * @param province the province to input
+	 * @param postalCode the postal code to input
+	 * @param country the country to select
+	 * @param effectiveFrom the effective from date to input
+	 * @param effectiveTo the effective to date to input
+	 * @param endReason the end reason to select
+	 * @param expectError if this action expect returning error messages
+	 * @return expected error message or empty string if no error message expected
+	 */
 	public String updateWLAddressDataBlock(int wlIndex, int entityIndex,
 									   String addressLine1, String addressLine2, String addressLine3,
 									   String city, String province, String postalCode, String country,
@@ -2152,12 +2169,12 @@ public class UpdateProviderPage extends ViewProviderPage {
 	/**
 	 * update Identifiers Data Block
 	 *
-	 * @param id
-	 * @param effectiveFrom
-	 * @param effectiveTo
-	 * @param endReasonCode
-	 * @param index
-	 * @param expectError
+	 * @param id			id
+	 * @param effectiveFrom effective from date
+	 * @param effectiveTo   effective to date
+	 * @param endReasonCode the end reason code
+	 * @param index		 the data block index to update
+	 * @param expectError   if error messages are expected
 	 * @return If there are error messages, return them; otherwise return an empty
 	 *         string.
 	 */
@@ -2191,11 +2208,11 @@ public class UpdateProviderPage extends ViewProviderPage {
 	/**
 	 * add Note Data Block
 	 *
-	 * @param id
-	 * @param text
-	 * @param effectiveFrom
-	 * @param effectiveTo
-	 * @param expectError
+	 * @param id the note id
+	 * @param text the note text
+	 * @param effectiveFrom effective from date
+	 * @param effectiveTo effective to date
+	 * @param expectError if error messages are expected
 	 * @return If there are error messages, return them; otherwise return an empty
 	 *         string.
 	 */
@@ -2233,12 +2250,12 @@ public class UpdateProviderPage extends ViewProviderPage {
 	/**
 	 * update Note Data Block
 	 *
-	 * @param text
-	 * @param effectiveFrom
-	 * @param effectiveTo
-	 * @param endReasonCode
-	 * @param index
-	 * @param expectError
+	 * @param text the note text
+	 * @param effectiveFrom effective from date
+	 * @param effectiveTo effective to date
+	 * @param endReasonCode the end reason code
+	 * @param index the data block index to update
+	 * @param expectError if error messages are expected
 	 * @return If there are error messages, return them; otherwise return an empty
 	 *         string
 	 */
@@ -2274,11 +2291,11 @@ public class UpdateProviderPage extends ViewProviderPage {
 	/**
 	 * add RegIdentifiers Data Block
 	 *
-	 * @param regIdType
-	 * @param regId
-	 * @param effectiveFrom
-	 * @param effectiveTo
-	 * @param expectError
+	 * @param regIdType the registry identifier type
+	 * @param regId the registry identifier
+	 * @param effectiveFrom effective from date
+	 * @param effectiveTo effective to date
+	 * @param expectError if error messages are expected
 	 * @return If there are error messages, return them; otherwise return an empty
 	 *         string
 	 */
@@ -2312,12 +2329,12 @@ public class UpdateProviderPage extends ViewProviderPage {
 	/**
 	 * update RegIdentifiers Data Block
 	 *
-	 * @param regId
-	 * @param effectiveFrom
-	 * @param effectiveTo
-	 * @param endReasonCode
-	 * @param index
-	 * @param expectError
+	 * @param regId the registry identifier
+	 * @param effectiveFrom effective from date
+	 * @param effectiveTo effective to date
+	 * @param endReasonCode the end reason code
+	 * @param index the data block index to update
+	 * @param expectError if error messages are expected
 	 * @return If there are error messages, return them; otherwise return an empty
 	 *         string
 	 */
@@ -2354,12 +2371,12 @@ public class UpdateProviderPage extends ViewProviderPage {
 	/**
 	 * add Status Data Block
 	 *
-	 * @param statusClassCode
-	 * @param statusCode
-	 * @param statusReasonCode
-	 * @param effectiveFrom
-	 * @param effectiveTo
-	 * @param expectError
+	 * @param statusClassCode the status class code
+	 * @param statusCode the status code
+	 * @param statusReasonCode the status reason code
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo the effective to date
+	 * @param expectError if error messages are expected
 	 * @return If there are error messages, return them; otherwise return an empty
 	 *         string
 	 */
@@ -2394,13 +2411,13 @@ public class UpdateProviderPage extends ViewProviderPage {
 	/**
 	 * update Status Data Block
 	 *
-	 * @param statusCode
-	 * @param statusReasonCode
-	 * @param effectiveFrom
-	 * @param effectiveTo
-	 * @param endReasonCode
-	 * @param index
-	 * @param expectError
+	 * @param statusCode the status class code
+	 * @param statusReasonCode the status code
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo the effective to date
+	 * @param endReasonCode the end reason code
+	 * @param index the data block index to update
+	 * @param expectError if error messages are expected
 	 * @return If there are error messages, return them; otherwise return an empty
 	 *         string
 	 */
@@ -2561,13 +2578,13 @@ public class UpdateProviderPage extends ViewProviderPage {
 	/**
 	 * update Note Data Block but click Cancel button at last
 	 *
-	 * @param text
-	 * @param effectiveFrom
-	 * @param effectiveTo
-	 * @param endReasonCode
-	 * @param index
-	 * @param expectError
-	 * @return
+	 * @param text the note text
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo the effective to date
+	 * @param endReasonCode the end reason code
+	 * @param index the data block index to update
+	 * @param expectError if error messages are expected
+	 * @return If there are error messages, return them; otherwise return an empty string
 	 */
 	public String updateNoteDataBlockCancel(String text, String effectiveFrom, String effectiveTo,
 			EndReason endReasonCode, int index, boolean expectError) {
@@ -2600,13 +2617,13 @@ public class UpdateProviderPage extends ViewProviderPage {
 	/**
 	 * update Identifier Data Block but click Cancel button at last
 	 *
-	 * @param id
-	 * @param effectiveFrom
-	 * @param effectiveTo
-	 * @param endReasonCode
-	 * @param index
+	 * @param id the identifier
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo the effective to date
+	 * @param endReasonCode the end reason code
+	 * @param index the data block index to update
 	 * @param b
-	 * @return
+	 * @return If there are error messages, return them; otherwise return an empty string
 	 */
 	public String updateIdentifierDataBlockCancel(String id, String effectiveFrom, String effectiveTo,
 			EndReason endReasonCode, int index, boolean b) {
@@ -2638,13 +2655,13 @@ public class UpdateProviderPage extends ViewProviderPage {
 	/**
 	 * update RegIdentifiers Data Block but click Cancel button at last
 	 *
-	 * @param regId
-	 * @param effectiveFrom
-	 * @param effectiveTo
-	 * @param endReasonCode
-	 * @param index
+	 * @param regId the registry identifier
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo the effective to date
+	 * @param endReasonCode the end reason code
+	 * @param index the data block index to update
 	 * @param b
-	 * @return
+	 * @return If there are error messages, return them; otherwise return an empty string
 	 */
 	public String updateRegIdentifiersDataBlockCancel(String regId, String effectiveFrom, String effectiveTo,
 			EndReason endReasonCode, int index, boolean b) {
@@ -2677,14 +2694,14 @@ public class UpdateProviderPage extends ViewProviderPage {
 	/**
 	 * update Status Data Block but click Cancel button at last
 	 *
-	 * @param statusCode
-	 * @param statusReasonCode
-	 * @param effectiveFrom
-	 * @param effectiveTo
-	 * @param endReasonCode
-	 * @param index
-	 * @param expectError
-	 * @return
+	 * @param statusCode the status code
+	 * @param statusReasonCode the status reason code
+	 * @param effectiveFrom the effective from date
+	 * @param effectiveTo the effective to date
+	 * @param endReasonCode the end reason code
+	 * @param index the data block index to update
+	 * @param expectError if error messages are expected
+	 * @return If there are error messages, return them; otherwise return an empty string
 	 */
 	public String updateStatusDataBlockCancel(String statusCode, String statusReasonCode, String effectiveFrom,
 			String effectiveTo, EndReason endReasonCode, int index, boolean expectError) {

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderLegacyTest.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderLegacyTest.java
@@ -824,6 +824,8 @@ public class UpdateProviderLegacyTest {
 		page.addWLAddressDataBlock(0, "P", "MC", "123 Test St",
 				null, null, "Victoria", "BC", "V1V1V1", "CA",
 				UpdateSimpleHelper.effective_date(), UpdateSimpleHelper.increment_year_for_effective_date(), false);
+
+		page.clickWLHeaderUpdateButton(ProviderSection.ADDRESSES, 0, 0);
 	}
 //
 //			Then Validate Electronic Address Txt

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderLegacyTest.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderLegacyTest.java
@@ -821,7 +821,9 @@ public class UpdateProviderLegacyTest {
 
 		page.addWorkLocationDataBlock("1", false, "Work Location", "CC", "Info", false);
 
-		page.clickWLHeaderAddButton(ProviderSection.ADDRESSES, 0);
+		page.addWLAddressDataBlock(0, "P", "MC", "123 Test St",
+				null, null, "Victoria", "BC", "V1V1V1", "CA",
+				UpdateSimpleHelper.effective_date(), UpdateSimpleHelper.increment_year_for_effective_date(), false);
 	}
 //
 //			Then Validate Electronic Address Txt

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderLegacyTest.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderLegacyTest.java
@@ -825,7 +825,9 @@ public class UpdateProviderLegacyTest {
 				null, null, "Victoria", "BC", "V1V1V1", "CA",
 				UpdateSimpleHelper.effective_date(), UpdateSimpleHelper.increment_year_for_effective_date(), false);
 
-		page.clickWLHeaderUpdateButton(ProviderSection.ADDRESSES, 0, 0);
+		page.updateWLAddressDataBlock(0, 0, "456 Test St",
+				null, null, "Victoria", "BC", "V0V0V0", "CA",
+				UpdateSimpleHelper.effective_date(), UpdateSimpleHelper.increment_year_for_effective_date(), EndReason.CHG, false);
 	}
 //
 //			Then Validate Electronic Address Txt

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderLegacyTest.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderLegacyTest.java
@@ -73,7 +73,7 @@ public class UpdateProviderLegacyTest {
 
 	@AfterClass
 	public void teardown() {
-		//workflowManager_.logoutAllAndClose();
+		workflowManager_.logoutAllAndClose();
 		LOG.info("Done.");
 	}
 
@@ -195,6 +195,12 @@ public class UpdateProviderLegacyTest {
 	public void testCodeRestrictionValidationIdentifier(ProviderType providerType) {
 		List<String> expectList = new ArrayList<>(Arrays.asList("CPN - Common Party Number",
 				"IPC - Internal Provider Code", "DENID - Dentist ID Number"));
+
+		if (providerType.equals(ProviderType.ORGANIZATION)) {
+			expectList.add("ORGID - Organization");
+			expectList.remove("DENID - Dentist ID Number");
+		}
+
 		PlrWebWorkflow workflow = TestHelper.logIn(workflowManager_, UserType.ADMIN);
 		UpdateProviderActions actions = workflowManager_.getSelectedWorkflow().getUpdateProviderActions();
 		String identifier = getTestProvideridentifier(providerType);
@@ -694,16 +700,16 @@ public class UpdateProviderLegacyTest {
 		
 		String msg = page.updateIdentifiersDataBlock(foreignID, UpdateSimpleHelper.effective_date(),
 				UpdateSimpleHelper.increment_year_for_effective_date(), EndReason.CHG, index, true);
-		assertTrue(msg.equals(errorMsg01));
+        assertEquals(errorMsg01, msg);
 		msg = page.updateIdentifiersDataBlock(nonnumericID, UpdateSimpleHelper.effective_date(),
 				UpdateSimpleHelper.increment_year_for_effective_date(), EndReason.CHG, index, true);
-		assertTrue(msg.equals(errorMsg01));
+        assertEquals(errorMsg01, msg);
 		msg = page.updateIdentifiersDataBlock(nonalphaID, UpdateSimpleHelper.effective_date(),
 				UpdateSimpleHelper.increment_year_for_effective_date(), EndReason.CHG, index, true);
-		assertTrue(msg.equals(errorMsg01));
+        assertEquals(errorMsg01, msg);
 		msg = page.updateIdentifiersDataBlock(null, UpdateSimpleHelper.effective_date(),
 				UpdateSimpleHelper.increment_year_for_effective_date(), EndReason.CHG, index, true);
-		assertTrue(msg.equals(errorMsg02));
+        assertEquals(errorMsg02, msg);
 	}
 
 //Then Validate Provider Identifiers For Update

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderLegacyTest.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderLegacyTest.java
@@ -73,7 +73,7 @@ public class UpdateProviderLegacyTest {
 
 	@AfterClass
 	public void teardown() {
-		workflowManager_.logoutAllAndClose();
+		//workflowManager_.logoutAllAndClose();
 		LOG.info("Done.");
 	}
 
@@ -809,6 +809,19 @@ public class UpdateProviderLegacyTest {
 		LinkedHashMap<String, String> content = page.grabDataBlockContent(ProviderSection.TELECOMMUNICATIONS, index);
         assertEquals(phoneNumber, content.get("Number"));
         assertEquals(areaCode, content.get("Area Code"));
+	}
+//			Then Validate Communication Purpose Type code
+	@Test(dataProvider = "indOrgTypes", dataProviderClass = InjectableData.class)
+	public void testValidateCommunicationPurposeTypeCode(ProviderType providerType) {
+		PlrWebWorkflow workflow = TestHelper.logIn(workflowManager_, UserType.ADMIN);
+		UpdateProviderActions actions = workflowManager_.getSelectedWorkflow().getUpdateProviderActions();
+		String identifier = getTestProvideridentifier(providerType);
+		String pauthId = UpdateSimpleHelper.getRegIdString("IPC", identifier);
+		UpdateProviderPage page = actions.openProvider(pauthId);
+
+		page.addWorkLocationDataBlock("1", false, "Work Location", "CC", "Info", false);
+
+		page.clickWLHeaderAddButton(ProviderSection.ADDRESSES, 0);
 	}
 //
 //			Then Validate Electronic Address Txt

--- a/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderLegacyTest.java
+++ b/autotest-plr/src/main/java/ca/bc/gov/health/qa/autotest/plr/web/tests/provider/UpdateProviderLegacyTest.java
@@ -1,9 +1,5 @@
 package ca.bc.gov.health.qa.autotest.plr.web.tests.provider;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -18,6 +14,8 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
@@ -50,6 +48,8 @@ import ca.bc.gov.health.qa.autotest.plr.web.tests.model.TelecommunicationType;
 import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflow;
 import ca.bc.gov.health.qa.autotest.plr.web.workflows.PlrWebWorkflowManager;
 import ca.bc.gov.health.qa.autotest.runner.util.log.ExecutionLogManager;
+
+import static org.testng.Assert.*;
 
 public class UpdateProviderLegacyTest {
 	private static final Logger LOG = ExecutionLogManager.getLogger();
@@ -422,7 +422,7 @@ public class UpdateProviderLegacyTest {
 				page.ceaseDataBlock(ProviderSection.IDENTIFIERS, i);
 			}
 			String msg = page.ceaseDataBlockWithError(ProviderSection.IDENTIFIERS, 0);
-			assertTrue(msg.equals(errorMsg));
+            assertEquals(errorMsg, msg);
 		}
 		if(UserType.SECONDARY.equals(userType)) {
 			// secondary has no permission to cease CPN/IPN
@@ -443,7 +443,7 @@ public class UpdateProviderLegacyTest {
 		page = actions.openProvider(pauthId);
 		page.ceaseAllDataBlockUnderSection(ProviderSection.IDENTIFIERS);
 		count = page.grabActiveDataBlockCount(ProviderSection.IDENTIFIERS, true);
-		assertTrue(count == 0);
+        assertEquals(count, 0);
 		workflowAdm.logout();
 		workflowAdm.close();
 		// ORG
@@ -459,7 +459,7 @@ public class UpdateProviderLegacyTest {
 				page.ceaseDataBlock(ProviderSection.IDENTIFIERS, i);
 			}
 			String msg = page.ceaseDataBlockWithError(ProviderSection.IDENTIFIERS, 0);
-			assertTrue(msg.equals(errorMsg));
+            assertEquals(errorMsg, msg);
 		}
 		if(UserType.SECONDARY.equals(userType)) {
 			// secondary has no permission to cease CPN/IPN
@@ -480,7 +480,7 @@ public class UpdateProviderLegacyTest {
 		page = actions.openProvider(pauthId);
 		page.ceaseAllDataBlockUnderSection(ProviderSection.IDENTIFIERS);
 		count = page.grabActiveDataBlockCount(ProviderSection.IDENTIFIERS, true);
-		assertTrue(count == 0);
+        assertEquals(count, 0);
 		workflowAdm.logout();
 		workflowAdm.close();
 		workflowManager_.logoutAllAndClose();
@@ -522,13 +522,13 @@ public class UpdateProviderLegacyTest {
 		}else {
 			// non-admin user type cannot see the reg id
 			int count=page.grabDataBlockCount(ProviderSection.REGISTRY_IDENTIFIERS);
-			assertTrue(count==0);
+            assertEquals(count, 0);
 		}
 		// search by CPN and return zero result--provider
 		SearchProviderPage searchProviderPage = workflow.getPlrWebAccessActions().openSearchProvider();
 		SearchProviderResultsFragment searchResults = searchProviderPage
 				.searchByRegistryIdentifier(IdentifierType.CPN.name(), pauthId);
-		if (UserType.ADMIN.equals(userType))assertTrue(searchResults.grabResultsRowCount() == 0);
+		if (UserType.ADMIN.equals(userType)) assertEquals(searchResults.grabResultsRowCount(), 0);
 		else assertTrue(searchResults.grabResultsRowCount() > 0);
 		// ORG
 		cpnString = defaultTestOrg.getIdentifier(IdentifierType.CPN);
@@ -547,12 +547,12 @@ public class UpdateProviderLegacyTest {
 		}else {
 			// non-admin user type cannot see the reg id
 			int count=page.grabDataBlockCount(ProviderSection.REGISTRY_IDENTIFIERS);
-			assertTrue(count==0);
+            assertEquals(count, 0);
 		}
 		// search by CPN and return zero result--org
 		searchProviderPage = workflow.getPlrWebAccessActions().openSearchProvider();
 		searchResults = searchProviderPage.searchByRegistryIdentifier(IdentifierType.CPN.name(), pauthId);
-		if (UserType.ADMIN.equals(userType))assertTrue(searchResults.grabResultsRowCount() == 0);
+		if (UserType.ADMIN.equals(userType)) assertEquals(searchResults.grabResultsRowCount(), 0);
 		else assertTrue(searchResults.grabResultsRowCount() > 0);
 		workflowManager_.logoutAndClose(userType);
 
@@ -621,7 +621,7 @@ public class UpdateProviderLegacyTest {
 				UpdateSimpleHelper.increment_year_for_effective_date(), EndReason.CHG, 0, false);
 		content = page.grabDataBlockContent(ProviderSection.NOTES, 0);
 		assertEquals(noteText, content.get("Note Text"));
-		assertTrue(!noteTextnew.equals(content.get("Note Text")));
+        assertNotEquals(content.get("Note Text"), noteTextnew);
 
 	}
 
@@ -736,20 +736,20 @@ public class UpdateProviderLegacyTest {
 		// invalid effective from
 		msg = page.updateIdentifiersDataBlock(newProviderId, "2026.03.24th",
 				UpdateSimpleHelper.increment_year_for_effective_date(), EndReason.CHG, index, true);
-		assertTrue(msg.equals(errorMsg01));
+        assertEquals(errorMsg01, msg);
 		// blank id
 		msg = page.updateIdentifiersDataBlock(null, UpdateSimpleHelper.effective_date(),
 				UpdateSimpleHelper.increment_year_for_effective_date(), EndReason.CHG, index, true);
-		assertTrue(msg.equals(errorMsg02));
+        assertEquals(errorMsg02, msg);
 		// blank effective from
 		String newProviderIdCancel = UpdateSimpleHelper.generateNumericString(10);
 		msg = page.updateIdentifiersDataBlock(newProviderIdCancel, null,
 				UpdateSimpleHelper.increment_year_for_effective_date(), EndReason.CHG, index, true);
-		assertTrue(msg.equals(errorMsg03));
+        assertEquals(errorMsg03, msg);
 		// null end reason
 		msg = page.updateIdentifiersDataBlock(newProviderIdCancel, UpdateSimpleHelper.effective_date(),
 				UpdateSimpleHelper.increment_year_for_effective_date(), null, index, true);
-		assertTrue(msg.equals(errorMsg04));
+        assertEquals(errorMsg04, msg);
 	}
 	
 	
@@ -831,9 +831,30 @@ public class UpdateProviderLegacyTest {
 				null, null, "Victoria", "BC", "V1V1V1", "CA",
 				UpdateSimpleHelper.effective_date(), UpdateSimpleHelper.increment_year_for_effective_date(), false);
 
-		page.updateWLAddressDataBlock(0, 0, "456 Test St",
-				null, null, "Victoria", "BC", "V0V0V0", "CA",
-				UpdateSimpleHelper.effective_date(), UpdateSimpleHelper.increment_year_for_effective_date(), EndReason.CHG, false);
+		page.addWLTelecomDataBlock(0, TelecommunicationType.PHONE.getText(), "BC",
+				UpdateSimpleHelper.generateNumericString(3), UpdateSimpleHelper.generateNumericString(7),
+				UpdateSimpleHelper.generateNumericString(4), UpdateSimpleHelper.effective_date(),
+				UpdateSimpleHelper.increment_year_for_effective_date(), false);
+
+		page.addWLElecAddressDataBlock(0, ElectronicAddressType.EMAIL.getText(), "BC", "test@test.com",
+				UpdateSimpleHelper.effective_date(), UpdateSimpleHelper.increment_year_for_effective_date(), false);
+
+		for (ProviderSection section : List.of(ProviderSection.ADDRESSES, ProviderSection.TELECOMMUNICATIONS, ProviderSection.ELECTRONIC_ADDRESSES)) {
+			final String xpath = String.format("//form[@id='%s']//div//label[contains(text(), 'Purpose')]/following::span[1]",
+					UpdateProviderPage.DIALOG_MAP.get(section).getFormName());
+
+			WebElement purpose = page.clickDataBlockUpdateButton(section, 0)
+					.findElement(By.xpath(xpath));
+			assertTrue(purpose.isDisplayed(), "Purpose field is not displayed in update dialog for section: " + section);
+			assertTrue(purpose.getText().contains("Contact"), "Purpose field does not contain 'Contact' in update dialog for section: " + section);
+			page.clickDialogCancelButton(section);
+
+			purpose = page.clickWLHeaderUpdateButton(section, 0, 0).findElement(By.xpath(xpath));
+			assertTrue(purpose.isDisplayed(), "Purpose field is not displayed in update dialog for Work Location section: " + section);
+			assertTrue(purpose.getText().contains("Contact"), "Purpose field does not contain 'Contact' in update dialog for section: " + section);
+			page.clickDialogCancelButton(section);
+		}
+
 	}
 //
 //			Then Validate Electronic Address Txt


### PR DESCRIPTION
This PR implements the more complex "Validate Communication Purpose Type code" test case that was skipped earlier - this involves checking the purpose code is not editable in Addresses/Telecommunications/Electronic Address in both the regular provider area and inside a work location.

Some miscellaneous assertion simplification and a bugfix for a test case in PLR-596 are also included.